### PR TITLE
Add helm dependency build

### DIFF
--- a/src/com/boxboat/jenkins/pipeline/deploy/kubernetes/HelmDeploy.groovy
+++ b/src/com/boxboat/jenkins/pipeline/deploy/kubernetes/HelmDeploy.groovy
@@ -12,6 +12,22 @@ class HelmDeploy implements Serializable {
 
     Map<String, Object> options = [:]
 
+    /**
+     * Update `helm dependency build` based on requirements.lock
+     */
+    public dependencyBuild() {
+        Config.pipeline.sh dependencyBuildScript()
+    }
+
+    public dependencyBuildScript() {
+        return """
+            helm_current_dir=\$(pwd)
+            cd "${directory}"
+            helm dependency build
+            cd "\$helm_current_dir"
+        """
+    }
+
     public install(Map<String, Object> additionalOptions = [:]) {
         Config.pipeline.sh installScript(additionalOptions)
     }


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

Add `helm dependency build` to process `requirements.lock` when the chart has sub chart requirements. The expectation is that the `.lock` file will be checked in, which is generated by `helm dependency update`