### PR TITLE
Add imagetag event logic to deploy.writeImageTags

### DIFF
--- a/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
+++ b/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
@@ -68,6 +68,18 @@ class GitBuildVersions implements Serializable {
         return Utils.resultOrTest(rc == 0, true)
     }
 
+    def writeImageVersion(String version, Image image, String outFile, String format) {
+        if (format != "yaml" && format != "env") {
+            throw new Exception("invalid format: '${format}'")
+        }
+
+        def key = "image_tag_${Utils.alphaNumericUnderscoreLower(image.path)}"
+        def divider = format == "yaml" ? ": " : "="
+        Config.pipeline.sh """
+            echo "${key}${divider}\\"${version}\\"" >> "$outFile"
+        """
+    }
+
     def setRepoEventVersion(String gitRemotePath, String event, SemVer semVer) {
         def dir = "${gitRepo.dir}/repo-versions/${gitRemotePath}"
         def path = "${dir}/${Utils.alphaNumericDashLower(event)}.txt"

--- a/src/com/boxboat/jenkins/pipeline/deploy/BoxDeploy.groovy
+++ b/src/com/boxboat/jenkins/pipeline/deploy/BoxDeploy.groovy
@@ -183,7 +183,13 @@ class BoxDeploy extends BoxBase<DeployConfig> implements Serializable {
             }
             config.imageOverrides.each imageOverridesCl
             deployment.imageOverrides.each imageOverridesCl
-            if (buildVersions.writeEventImageVersion(event, image, params.outFile, params.format)) {
+            if (Utils.isImageTagEvent(event)) {
+                image.tag = Utils.imageTagFromEvent(event)
+                buildVersions.writeImageVersion(image.tag, image, params.outFile, params.format)
+                notifySuccessMessage += "\n${image.path} version: ${image.tag}"
+                imageSummary += "\n${image.path}:${image.tag}"
+                return
+            } else if (buildVersions.writeEventImageVersion(event, image, params.outFile, params.format)) {
                 image.tag = buildVersions.getEventImageVersion(event, image)
                 notifySuccessMessage += "\n${image.path} version: ${image.tag}"
                 config.getEventRegistries(event).each { registry ->
@@ -193,7 +199,13 @@ class BoxDeploy extends BoxBase<DeployConfig> implements Serializable {
             }
             String triedEvents = event
             if (eventFallback) {
-                if (buildVersions.writeEventImageVersion(eventFallback, image, params.outFile, params.format)) {
+                if (Utils.isImageTagEvent(eventFallback)) {
+                    image.tag = Utils.imageTagFromEvent(eventFallback)
+                    buildVersions.writeImageVersion(image.tag, image, params.outFile, params.format)
+                    notifySuccessMessage += "\n${image.path} version: ${image.tag}"
+                    imageSummary += "\n${image.path}:${image.tag}"
+                    return
+                } else if (buildVersions.writeEventImageVersion(eventFallback, image, params.outFile, params.format)) {
                     image.tag = buildVersions.getEventImageVersion(eventFallback, image)
                     notifySuccessMessage += "\n${image.path} version: ${image.tag}"
                     config.getEventRegistries(eventFallback).each { registry ->


### PR DESCRIPTION
Adds logic to consider `imageTag/<tag>` events in `BoxDeploy.writeImageTags`