### PR TITLE
Add notify config object

### DIFF
--- a/docs/config/common.md
+++ b/docs/config/common.md
@@ -37,24 +37,42 @@ common:
     - test/b
 ```
 
-## notifySuccessKeys
+## notify
 
-Notify targets to send success notifications to
+Notification settings.  Keys are references to targets defined in `targetMap` or the global `notifyTargetMap`.
+Supported notification target types are:
 
-```yaml
-common:
-  notifySuccessKeys:
-    - slack-success
-```
-
-## notifyFailureKeys
-
-Notify targets to send failure notifications to
+- `com.boxboat.jenkins.library.notify.SlackWebHookNotifyTarget`
+  - For use with the [Slack Incoming Webhooks App](https://boxboat.slack.com/apps/A0F7XDUAZ-incoming-webhooks?next_id=0)
+  - Jenkins Credential referenced in `credential` is a Secret Text credential with the full webhook URL
+- `com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget`
+  - For use with the [Slack Jenkns CI App](https://boxboat.slack.com/apps/A0F7VRFKN-jenkins-ci?next_id=0)
+  - Use `channel` to override channel
 
 ```yaml
 common:
-  notifyFailureKeys:
-    - slack-failure
+  notify:
+    targetMap:
+      jenkins: !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+        channel: "#jenkins"
+    successKeys:
+      - default
+      - jenkins
+    successTargets:
+      - !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+        channel: "#jenkins-success"
+    failureKeys:
+      - default
+      - jenkins
+    failureTargets:
+      - !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+        channel: "#jenkins-failure"
+    infoKeys:
+      - default
+      - jenkins
+    infoTargets:
+      - !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+        channel: "#jenkins-info"
 ```
 
 ## vaultKey

--- a/resources/com/boxboat/jenkins/config.example.yaml
+++ b/resources/com/boxboat/jenkins/config.example.yaml
@@ -37,10 +37,28 @@ vaultMap:
 repo:
   common:
     defaultBranch: master
-    notifySuccessKeys:
-      - default
-    notifyFailureKeys:
-      - default
+    notify:
+      targetMap:
+        jenkins: !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+          channel: "#jenkins"
+      successKeys:
+        - default
+        - jenkins
+      successTargets:
+        - !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+          channel: "#jenkins-success"
+      failureKeys:
+        - default
+        - jenkins
+      failureTargets:
+        - !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+          channel: "#jenkins-failure"
+      infoKeys:
+        - default
+        - jenkins
+      infoTargets:
+        - !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+          channel: "#jenkins-info"
     vaultKey: default
     eventRegistryKeys:
       - event: commit/master

--- a/src/com/boxboat/jenkins/library/config/BaseConfig.groovy
+++ b/src/com/boxboat/jenkins/library/config/BaseConfig.groovy
@@ -46,7 +46,7 @@ abstract class BaseConfig<T> implements Serializable, ICopyableConfig<T>, IMerge
 
     public Map asMap() {
         this.class.declaredFields.findAll { !it.synthetic }.collectEntries {
-            [ (it.name):this."$it.name" ]
+            [(it.name): this."$it.name"]
         }
     }
 

--- a/src/com/boxboat/jenkins/library/config/CommonConfigBase.groovy
+++ b/src/com/boxboat/jenkins/library/config/CommonConfigBase.groovy
@@ -3,7 +3,7 @@ package com.boxboat.jenkins.library.config
 import com.boxboat.jenkins.library.docker.Image
 import com.boxboat.jenkins.library.docker.Registry
 import com.boxboat.jenkins.library.event.EventRegistryKey
-import com.boxboat.jenkins.library.trigger.Trigger
+import com.boxboat.jenkins.library.notify.NotifyConfig
 
 class CommonConfigBase<T> extends BaseConfig<T> {
 
@@ -13,9 +13,7 @@ class CommonConfigBase<T> extends BaseConfig<T> {
 
     List<Image> images
 
-    List<String> notifySuccessKeys
-
-    List<String> notifyFailureKeys
+    NotifyConfig notify
 
     String vaultKey
 

--- a/src/com/boxboat/jenkins/library/config/GlobalConfig.groovy
+++ b/src/com/boxboat/jenkins/library/config/GlobalConfig.groovy
@@ -39,14 +39,6 @@ class GlobalConfig extends BaseConfig<GlobalConfig> implements Serializable {
         return environment
     }
 
-    INotifyTarget getNotifyTarget(String key) {
-        def provider = notifyTargetMap.get(key)
-        if (!provider) {
-            throw new Exception("notifyTargetMap entry '${key}' does not exist in config file")
-        }
-        return provider
-    }
-
     Registry getRegistry(String key) {
         def registry = registryMap.get(key)
         if (!registry) {

--- a/src/com/boxboat/jenkins/library/notify/NotifyConfig.groovy
+++ b/src/com/boxboat/jenkins/library/notify/NotifyConfig.groovy
@@ -1,0 +1,45 @@
+package com.boxboat.jenkins.library.notify
+
+import com.boxboat.jenkins.library.config.BaseConfig
+import com.boxboat.jenkins.library.config.Config
+
+class NotifyConfig extends BaseConfig<NotifyConfig> implements Serializable {
+
+    Map<String, INotifyTarget> targetMap
+
+    List<String> successKeys
+
+    List<INotifyTarget> successTargets
+
+    List<String> failureKeys
+
+    List<INotifyTarget> failureTargets
+
+    List<String> infoKeys
+
+    List<INotifyTarget> infoTargets
+
+    INotifyTarget getNotifyTarget(String key) {
+        def target = targetMap.get(key)
+        if (!target) {
+            target = Config.global.notifyTargetMap.get(key)
+        }
+        if (!target) {
+            throw new Exception("notify target entry '${key}' does not exist in repository notify.targetMap or global notifyTargetMap")
+        }
+        return target
+    }
+
+    List<INotifyTarget> successTargets() {
+        return successTargets + successKeys.collect { key -> return getNotifyTarget(key) }
+    }
+
+    List<INotifyTarget> failureTargets() {
+        return failureTargets + failureKeys.collect { key -> return getNotifyTarget(key) }
+    }
+
+    List<INotifyTarget> infoTargets() {
+        return infoTargets + infoKeys.collect { key -> return getNotifyTarget(key) }
+    }
+
+}

--- a/src/com/boxboat/jenkins/library/notify/NotifyType.groovy
+++ b/src/com/boxboat/jenkins/library/notify/NotifyType.groovy
@@ -3,4 +3,5 @@ package com.boxboat.jenkins.library.notify
 enum NotifyType {
     FAILURE,
     SUCCESS,
+    INFO,
 }

--- a/test-resources/com/boxboat/jenkins/test/library/config/globalConfig/test.yaml
+++ b/test-resources/com/boxboat/jenkins/test/library/config/globalConfig/test.yaml
@@ -37,10 +37,28 @@ vaultMap:
 repo:
   common:
     defaultBranch: master
-    notifySuccessKeys:
-      - default
-    notifyFailureKeys:
-      - default
+    notify:
+      targetMap:
+        jenkins: !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+          channel: "#jenkins"
+      successKeys:
+        - default
+        - jenkins
+      successTargets:
+        - !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+          channel: "#jenkins-success"
+      failureKeys:
+        - default
+        - jenkins
+      failureTargets:
+        - !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+          channel: "#jenkins-failure"
+      infoKeys:
+        - default
+        - jenkins
+      infoTargets:
+        - !!com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
+          channel: "#jenkins-info"
     vaultKey: default
     eventRegistryKeys:
       - event: commit/master

--- a/test/com/boxboat/jenkins/test/library/config/GlobalConfigTest.groovy
+++ b/test/com/boxboat/jenkins/test/library/config/GlobalConfigTest.groovy
@@ -1,6 +1,6 @@
 package com.boxboat.jenkins.test.library.config
 
-
+import com.boxboat.jenkins.library.notify.SlackJenkinsAppNotifyTarget
 import com.boxboat.jenkins.library.vault.Vault
 import com.boxboat.jenkins.library.config.CommonConfig
 import com.boxboat.jenkins.library.config.DeployConfig
@@ -107,11 +107,39 @@ class GlobalConfigTest {
                                 repo: [
                                         common : new CommonConfig(
                                                 defaultBranch: "master",
-                                                notifySuccessKeys: [
-                                                        "default"
-                                                ],
-                                                notifyFailureKeys: [
-                                                        "default"
+                                                notify: [
+                                                        "targetMap"     : [
+                                                                "jenkins": new SlackJenkinsAppNotifyTarget(
+                                                                        channel: "#jenkins"
+                                                                ),
+                                                        ],
+                                                        "successKeys"   : [
+                                                                "default",
+                                                                "jenkins",
+                                                        ],
+                                                        successTargets  : [
+                                                                new SlackJenkinsAppNotifyTarget(
+                                                                        channel: "#jenkins-success"
+                                                                ),
+                                                        ],
+                                                        "failureKeys"   : [
+                                                                "default",
+                                                                "jenkins",
+                                                        ],
+                                                        "failureTargets": [
+                                                                new SlackJenkinsAppNotifyTarget(
+                                                                        channel: "#jenkins-failure"
+                                                                ),
+                                                        ],
+                                                        "infoKeys"      : [
+                                                                "default",
+                                                                "jenkins",
+                                                        ],
+                                                        "infoTargets"   : [
+                                                                new SlackJenkinsAppNotifyTarget(
+                                                                        channel: "#jenkins-info"
+                                                                ),
+                                                        ],
                                                 ],
                                                 eventRegistryKeys: [
                                                         new EventRegistryKey(

--- a/test/com/boxboat/jenkins/test/pipeline/PipelineBase.groovy
+++ b/test/com/boxboat/jenkins/test/pipeline/PipelineBase.groovy
@@ -34,6 +34,7 @@ abstract class PipelineBase extends BasePipelineTest {
         helper.registerAllowedMethod('withKubeConfig', [Map.class, Closure.class], {
             config, next -> next()
         })
+        helper.registerAllowedMethod('slackSend', [Map.class], null)
 
         binding.setVariable('env', [
                 'sshKey'         : 'sshKey',


### PR DESCRIPTION
Currently, repositories can only define `notifySuccessKeys` and `notifyFailureKeys`, and all notification targets must be globally defined

Many repositories may want to define their own notification targets without updating the global `notifyTargetMap`

This PR introduces a new `NotifyConfig` object that repositories can define, allowing for:
- `targetMap` new targets that the repository adds that can be referenced by key
- `successKeys` from `targetMap` or global `notifyTargetMap`
- `successTargets` new targets that the repository adds
- `failureKeys` from `targetMap` or global `notifyTargetMap`
- `failureTargets` new targets that the repository adds
- `infoKeys` from `targetMap` or global `notifyTargetMap`
- `infoTargets` new targets that the repository adds

This is a breaking change, as `notifySuccessKeys` and `notifyFailureKeys` have been removed