### PR TITLE
Emit prerelease triggers when release is incremented

### DIFF
--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -167,6 +167,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
                 if (v.promoteToEvent?.startsWith("tag/")) {
                     def currentSemVer = buildVersions.getRepoEventVersion(gitRepo.getRemotePath(), v.promoteToEvent)
                     if (nextSemVer > currentSemVer) {
+                        emitEvents.add(v.promoteToEvent)
                         promoteClosure(v.promoteToEvent)
                     }
                 }


### PR DESCRIPTION
Prerelease tags are incremented when `tag/release` is incremented

This PR emits those events, so that triggers will run against them