### PR TITLE
Add helm delete to HelmDeploy

### DIFF
--- a/src/com/boxboat/jenkins/pipeline/deploy/kubernetes/HelmDeploy.groovy
+++ b/src/com/boxboat/jenkins/pipeline/deploy/kubernetes/HelmDeploy.groovy
@@ -13,6 +13,19 @@ class HelmDeploy implements Serializable {
     Map<String, Object> options = [:]
 
     /**
+     * Delete helm deployment
+     */
+    public delete() {
+        Config.pipeline.sh deleteScript()
+    }
+
+    public deleteScript() {
+        return """
+            helm delete ${name} --purge
+        """
+    }
+
+    /**
      * Update `helm dependency build` based on requirements.lock
      */
     public dependencyBuild() {

--- a/src/com/boxboat/jenkins/pipeline/deploy/kubernetes/HelmDeploy.groovy
+++ b/src/com/boxboat/jenkins/pipeline/deploy/kubernetes/HelmDeploy.groovy
@@ -21,7 +21,7 @@ class HelmDeploy implements Serializable {
 
     public deleteScript() {
         return """
-            helm delete ${name} --purge
+            helm delete "${name}" --purge
         """
     }
 

--- a/test/com/boxboat/jenkins/test/pipeline/deploy/kubernetes/HelmDeployTest.groovy
+++ b/test/com/boxboat/jenkins/test/pipeline/deploy/kubernetes/HelmDeployTest.groovy
@@ -32,6 +32,10 @@ class HelmDeployTest {
             helm upgrade -f "values1.yaml" -f "values3.yaml" --install "test" "."
             cd "\$helm_current_dir"
         """.trim())
+        def deleteScript = helmDeploy.deleteScript()
+        assertEquals(deleteScript.trim(),"""
+            helm delete "test" --purge
+        """.trim())
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

Adds helm delete to HelmDeploy to allow for custom deployment use cases where the deployment pipeline needs the ability to delete a helm release