### PR TITLE
Add the ability to specify replica environment deployments in the environmentMap

### DIFF
--- a/resources/com/boxboat/jenkins/config.example.yaml
+++ b/resources/com/boxboat/jenkins/config.example.yaml
@@ -5,11 +5,19 @@ deployTargetMap:
   prod01: !!com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget
     contextName: boxboat
     credential: kubeconfig-prod
+  prod02: !!com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget
+    contextName: boxboat
+    credential: kubeconfig-prod-02
 environmentMap:
   dev:
+    name: dev
     deployTargetKey: dev01
   prod:
+    name: prod-a
     deployTargetKey: prod01
+    replicaEnvironments:
+      - name: prod-b
+        deployTargetKey: prod02
 git:
   buildVersionsUrl: git@github.com/boxboat/build-versions.git
   credential: git

--- a/src/com/boxboat/jenkins/library/config/BaseConfig.groovy
+++ b/src/com/boxboat/jenkins/library/config/BaseConfig.groovy
@@ -96,12 +96,13 @@ abstract class BaseConfig<T> implements Serializable, ICopyableConfig<T>, IMerge
         T m = (T) o
 
         def equalsBuilder = new EqualsBuilder()
-        this.properties.keySet().toList().each { k ->
-            def v = this.properties[k]
-            if (k == "class") {
+        this.class.metaClass.properties.each { property ->
+            def name = property.name
+            if (name != "class"
+                    && !Modifier.isStatic(property.getModifiers())) {
                 return
             }
-            equalsBuilder.append(v, m."$k")
+            equalsBuilder.append(m."${name}", o."${name}")
         }
         return equalsBuilder.equals
     }

--- a/src/com/boxboat/jenkins/library/config/DeployConfig.groovy
+++ b/src/com/boxboat/jenkins/library/config/DeployConfig.groovy
@@ -1,13 +1,17 @@
 package com.boxboat.jenkins.library.config
 
+
 import com.boxboat.jenkins.library.deploy.Deployment
 import com.boxboat.jenkins.library.docker.Image
+import com.boxboat.jenkins.library.environment.Environment
 
 class DeployConfig extends CommonConfigBase<DeployConfig> implements Serializable {
 
     String deploymentKey
 
     String deployTargetKey
+
+    List<Environment> replicaEnvironments
 
     Map<String, Deployment> deploymentMap
 

--- a/src/com/boxboat/jenkins/library/environment/BaseEnvironment.groovy
+++ b/src/com/boxboat/jenkins/library/environment/BaseEnvironment.groovy
@@ -1,0 +1,19 @@
+package com.boxboat.jenkins.library.environment
+
+import com.boxboat.jenkins.library.config.BaseConfig
+import com.boxboat.jenkins.library.config.Config
+import com.boxboat.jenkins.library.deployTarget.IDeployTarget
+
+class BaseEnvironment  extends BaseConfig<BaseEnvironment> implements Serializable {
+    String name
+
+    String deployTargetKey
+
+    IDeployTarget getDeployTarget() {
+        return Config.global.getDeployTarget(deployTargetKey)
+    }
+
+    void withCredentials(closure) {
+        getDeployTarget().withCredentials(closure)
+    }
+}

--- a/src/com/boxboat/jenkins/library/environment/Environment.groovy
+++ b/src/com/boxboat/jenkins/library/environment/Environment.groovy
@@ -1,9 +1,10 @@
 package com.boxboat.jenkins.library.environment
 
-import com.boxboat.jenkins.library.config.BaseConfig
+class Environment extends BaseEnvironment implements Serializable {
 
-class Environment extends BaseConfig<Environment> implements Serializable {
+    List<BaseEnvironment> replicaEnvironments = []
 
-    String deployTargetKey
-
+    List<BaseEnvironment> allEnvironments() {
+        return [this as BaseEnvironment] + replicaEnvironments
+    }
 }

--- a/test-resources/com/boxboat/jenkins/test/library/config/globalConfig/test.yaml
+++ b/test-resources/com/boxboat/jenkins/test/library/config/globalConfig/test.yaml
@@ -5,11 +5,19 @@ deployTargetMap:
   prod01: !!com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget
     contextName: boxboat
     credential: kubeconfig-prod
+  prod02: !!com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget
+    contextName: boxboat
+    credential: kubeconfig-prod-02
 environmentMap:
   dev:
+    name: dev
     deployTargetKey: dev01
   prod:
+    name: prod-a
     deployTargetKey: prod01
+    replicaEnvironments:
+      - name: prod-b
+        deployTargetKey: prod02
 git:
   buildVersionsUrl: git@github.com/boxboat/build-versions.git
   credential: git

--- a/test-resources/com/boxboat/jenkins/test/pipeline/multiDeployment.jenkins
+++ b/test-resources/com/boxboat/jenkins/test/pipeline/multiDeployment.jenkins
@@ -1,0 +1,45 @@
+@Library('jenkins-shared-library@master')
+import com.boxboat.jenkins.pipeline.common.vault.*
+import com.boxboat.jenkins.pipeline.deploy.*
+import com.boxboat.jenkins.library.environment.*
+
+def execute() {
+
+    params.deploymentKey = "prod"
+    def deploy = new BoxDeploy(
+        globalConfigPath: "com/boxboat/jenkins/config.example.yaml",
+        config: [
+            images: [
+                "test/a",
+                "test/b",
+            ],
+        ]
+    )
+
+    node() {
+        deploy.wrap {
+            stage('Deploy'){
+                deploy.writeImageTags(
+                    outFile: "image-tags.yaml",
+                    yamlPath: ["global"],
+                )
+                VaultSecretScriptHelper.file(
+                    base64: true,
+                    format: "env",
+                    outFile: "env-vars.yaml",
+                    vaultPaths: ["secret/test"],
+                    yamlPath: ["global", "envVarsFileContent"],
+                )
+                def replicas = deploy.allEnvironments()
+                for (int i = 0; i < replicas.size(); i++) {
+                    replicas[i].withCredentials() {
+                        sh "helm upgrade --install test --values values-${replicas[i].name}.yaml ."
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+return this

--- a/test/com/boxboat/jenkins/test/library/config/GlobalConfigTest.groovy
+++ b/test/com/boxboat/jenkins/test/library/config/GlobalConfigTest.groovy
@@ -7,8 +7,10 @@ import com.boxboat.jenkins.library.config.DeployConfig
 import com.boxboat.jenkins.library.config.GlobalConfig
 import com.boxboat.jenkins.library.config.PromoteConfig
 import com.boxboat.jenkins.library.deploy.Deployment
+
 import com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget
 import com.boxboat.jenkins.library.docker.Registry
+import com.boxboat.jenkins.library.environment.BaseEnvironment
 import com.boxboat.jenkins.library.environment.Environment
 import com.boxboat.jenkins.library.event.EventRegistryKey
 import com.boxboat.jenkins.library.git.GitConfig
@@ -64,13 +66,25 @@ class GlobalConfigTest {
                                                 contextName: "boxboat",
                                                 credential: "kubeconfig-prod",
                                         ),
+                                        "prod02": new KubernetesDeployTarget(
+                                                contextName: "boxboat",
+                                                credential: "kubeconfig-prod-02",
+                                        ),
                                 ],
                                 environmentMap: [
                                         "dev" : new Environment(
+                                                name: "dev",
                                                 deployTargetKey: "dev01",
                                         ),
                                         "prod": new Environment(
+                                                name: "prod-a",
                                                 deployTargetKey: "prod01",
+                                                replicaEnvironments: [
+                                                     new BaseEnvironment(
+                                                         name: "prod-b",
+                                                         deployTargetKey: "prod02"
+                                                     )
+                                                ]
                                         ),
                                 ],
                                 git: new GitConfig(

--- a/test/com/boxboat/jenkins/test/pipeline/deploy/MultiDeploymentTest.groovy
+++ b/test/com/boxboat/jenkins/test/pipeline/deploy/MultiDeploymentTest.groovy
@@ -1,0 +1,21 @@
+package com.boxboat.jenkins.test.pipeline.deploy
+
+import com.boxboat.jenkins.test.pipeline.PipelineBase
+import org.junit.Before
+import org.junit.Test
+
+class MultiDeploymentTest extends PipelineBase {
+
+    @Override
+    @Before
+    void setUp() throws Exception {
+        super.setUp()
+    }
+
+    @Test
+    void deploymentTest() throws Exception {
+        def script = loadScript("${this.scriptBase}multiDeployment.jenkins")
+        script.execute()
+        printCallStack()
+    }
+}


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>
Closes #12 

Added the ability to specify `replicaEnvironments` in the `environmentMap` to allow BoxDeploy to expose multiple `Environments` for a deployment