### PR TITLE
BoxPromote and semver bugfix

### DIFF
--- a/src/com/boxboat/jenkins/library/SemVer.groovy
+++ b/src/com/boxboat/jenkins/library/SemVer.groovy
@@ -74,6 +74,7 @@ class SemVer implements Comparable<SemVer>, Serializable {
         }
         preReleaseNumber++
         preRelease = "${preReleaseType}${preReleaseNumber}"
+        isPreRelease = true
     }
 
     SemVer copy() {

--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -114,7 +114,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
         }
         if (tagType != "release") {
             def releaseSemVer = buildVersions.getRepoEventVersion(gitRepo.getRemotePath(), "tag/release")
-            if (releaseSemVer != null && releaseSemVer.isValid && releaseSemVer > nextSemVer) {
+            if (releaseSemVer != null && releaseSemVer.isValid && releaseSemVer >= nextSemVer) {
                 nextSemVer = releaseSemVer.copy()
                 nextSemVer.patch++
             }


### PR DESCRIPTION
- Fix bug in `BoxPromote` that prevents non-release semver from being incremented when non-release semver == release semver
- Fix bug in `SemVer` where `isPreRelease` is not set after calling `incrementPreRelease()`