### PR TITLE
Add `dir` property to change into directory after checkout

### DIFF
--- a/docs/pipelines/box-build.md
+++ b/docs/pipelines/box-build.md
@@ -1,6 +1,6 @@
 # BoxBuild
 
-All methods from [BoxCommon](box-common.md) are valid in addition to the methods documented here.
+All properties and methods from [BoxCommon](box-common.md) are valid in addition to the properties and methods documented here.
 
 ## Methods
 

--- a/docs/pipelines/box-common.md
+++ b/docs/pipelines/box-common.md
@@ -2,6 +2,12 @@
 
 Base class for pipelines
 
+## Properties
+
+### dir
+
+Directory to change into after checking out from SCM
+
 ## Methods
 
 ### wrap()
@@ -18,7 +24,9 @@ Sends success notifications upon build success and failure notifications upon bu
 @Library('jenkins-shared-library@master')
 import com.boxboat.jenkins.pipeline.common.*
 
-def common = new BoxCommon()
+def common = new BoxCommon(
+  dir: "./test"
+)
 
 node() {
   common.wrap {

--- a/docs/pipelines/box-deploy.md
+++ b/docs/pipelines/box-deploy.md
@@ -1,6 +1,6 @@
 # BoxDeploy
 
-All methods from [BoxCommon](box-common.md) are valid in addition to the methods documented here.
+All properties and methods from [BoxCommon](box-common.md) are valid in addition to the properties and methods documented here.
 
 ## Methods
 

--- a/docs/pipelines/box-promote.md
+++ b/docs/pipelines/box-promote.md
@@ -1,6 +1,6 @@
 # BoxPromote
 
-All methods from [BoxCommon](box-common.md) are valid in addition to the methods documented here.
+All properties and methods from [BoxCommon](box-common.md) are valid in addition to the properties and methods documented here.
 
 ## Methods
 

--- a/src/com/boxboat/jenkins/library/LibraryScript.groovy
+++ b/src/com/boxboat/jenkins/library/LibraryScript.groovy
@@ -2,15 +2,18 @@ package com.boxboat.jenkins.library
 
 import com.boxboat.jenkins.library.config.Config
 
+import java.nio.file.Paths
+
 class LibraryScript implements Serializable {
 
     static String run(String script) {
-        def path = "sharedLibraryScripts/${script}"
-        if (Config.pipeline && !Config.pipeline.fileExists(path)) {
-            String data = Config.pipeline.libraryResource(resource: "com/boxboat/jenkins/${path}", encoding: "Base64")
-            Config.pipeline.writeFile(file: path, text: data, encoding: "Base64")
-            Config.pipeline.sh "chmod +x ${path}"
+        def relativePath = Paths.get("sharedLibraryScripts", script).toString()
+        def absolutePath = Paths.get(Config.baseDir, relativePath).normalize().toAbsolutePath().toString()
+        if (Config.pipeline && !Config.pipeline.fileExists(absolutePath)) {
+            String data = Config.pipeline.libraryResource(resource: "com/boxboat/jenkins/${relativePath}", encoding: "Base64")
+            Config.pipeline.writeFile(file: absolutePath, text: data, encoding: "Base64")
+            Config.pipeline.sh "chmod +x ${absolutePath}"
         }
-        return "./${path}"
+        return absolutePath
     }
 }

--- a/src/com/boxboat/jenkins/library/Utils.groovy
+++ b/src/com/boxboat/jenkins/library/Utils.groovy
@@ -2,6 +2,8 @@ package com.boxboat.jenkins.library
 
 import com.boxboat.jenkins.library.config.Config
 
+import java.nio.file.Paths
+
 class Utils implements Serializable {
 
     static String cleanEvent(String event) {
@@ -93,6 +95,10 @@ class Utils implements Serializable {
             return test
         }
         return result
+    }
+
+    static String toAbsolutePath(String relativePath) {
+        return Paths.get(Config.pipeline.pwd(), relativePath).normalize().toAbsolutePath().toString()
     }
 
 }

--- a/src/com/boxboat/jenkins/library/config/Config.groovy
+++ b/src/com/boxboat/jenkins/library/config/Config.groovy
@@ -2,6 +2,10 @@ package com.boxboat.jenkins.library.config
 
 class Config implements Serializable {
 
+    static String baseDir = "./"
+
+    static String scmDir = "./"
+
     static GlobalConfig global
 
     static CommonConfigBase repo

--- a/src/com/boxboat/jenkins/library/git/GitAccount.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitAccount.groovy
@@ -1,5 +1,6 @@
 package com.boxboat.jenkins.library.git
 
+import com.boxboat.jenkins.library.Utils
 import com.boxboat.jenkins.library.config.Config
 
 class GitAccount implements Serializable {
@@ -43,11 +44,11 @@ class GitAccount implements Serializable {
             exit 0
         """
         def checkoutData = Config.pipeline.checkout Config.pipeline.scm
-        return new GitRepo(relativeDir: ".", checkoutData: checkoutData)
+        return new GitRepo(dir: Utils.toAbsolutePath("."), checkoutData: checkoutData)
     }
 
     // Checkout Remote Repository into a targetDir
-    def checkoutRepository(remoteUrl, targetDir, depth = 0) {
+    def checkoutRepository(String remoteUrl, String targetDir, int depth = 0) {
         _ensureInitialized()
         def depthStr = ""
         if (depth > 0) {
@@ -60,7 +61,7 @@ class GitAccount implements Serializable {
             git clone ${depthStr} "${remoteUrl}" .
         """
 
-        return new GitRepo(relativeDir: targetDir)
+        return new GitRepo(dir: Utils.toAbsolutePath(targetDir))
     }
 
 }

--- a/src/com/boxboat/jenkins/library/git/GitRepo.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitRepo.groovy
@@ -75,12 +75,14 @@ class GitRepo implements Serializable {
     }
 
     def checkout(String checkout) {
-        Config.pipeline.sh """
-            cd "${this.dir}"
-            git checkout "${checkout}"
-            git reset --hard
-            git clean -fd
-        """
+        // git clean must be executed inside Config.pipeline.dir block
+        Config.pipeline.dir(dir) {
+            Config.pipeline.sh """
+                git checkout "${checkout}"
+                git reset --hard
+                git clean -ffd
+            """
+        }
     }
 
     boolean currentBranchContainsCommit(String commit) {
@@ -91,11 +93,13 @@ class GitRepo implements Serializable {
     }
 
     def resetToHash(String commitHash) {
-        Config.pipeline.sh """
-            cd "${this.dir}"
-            git reset --hard "${commitHash}"
-            git clean -fd
-        """
+        // git clean must be executed inside Config.pipeline.dir block
+        Config.pipeline.dir(dir) {
+            Config.pipeline.sh """
+                git reset --hard "${commitHash}"
+                git clean -ffd
+            """
+        }
     }
 
     def tagAndPush(String tag) {
@@ -107,11 +111,13 @@ class GitRepo implements Serializable {
     }
 
     def resetAndClean() {
-        Config.pipeline.sh """
-            cd "${this.dir}"
-            git reset --hard
-            git clean -fd
-        """
+        // git clean must be executed inside Config.pipeline.dir block
+        Config.pipeline.dir(dir) {
+            Config.pipeline.sh """
+                git reset --hard
+                git clean -ffd
+            """
+        }
     }
 
     // Requires 'Checkout over SSH' setting in Jenkins

--- a/src/com/boxboat/jenkins/library/git/GitRepo.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitRepo.groovy
@@ -3,21 +3,10 @@ package com.boxboat.jenkins.library.git
 import com.boxboat.jenkins.library.Utils
 import com.boxboat.jenkins.library.config.Config
 
-import java.nio.file.Paths
-
 class GitRepo implements Serializable {
 
     public checkoutData = [:]
-    public relativeDir
-
-    protected String dir
-
-    public String getDir() {
-        if (!dir) {
-            dir = Paths.get(Config.pipeline.env.WORKSPACE, relativeDir).toAbsolutePath().toString()
-        }
-        return dir
-    }
+    public dir
 
     String getHash() {
         return Utils.resultOrTest(Config.pipeline.sh(returnStdout: true, script: """

--- a/src/com/boxboat/jenkins/pipeline/BoxBase.groovy
+++ b/src/com/boxboat/jenkins/pipeline/BoxBase.groovy
@@ -1,5 +1,6 @@
 package com.boxboat.jenkins.pipeline
 
+import com.boxboat.jenkins.library.Utils
 import com.boxboat.jenkins.library.buildVersions.GitBuildVersions
 import com.boxboat.jenkins.library.config.CommonConfigBase
 import com.boxboat.jenkins.library.config.Config
@@ -25,6 +26,7 @@ abstract class BoxBase<T extends CommonConfigBase> implements Serializable {
     public String triggerEvent
     public String triggerImagePathsCsv
     public String buildUser = "Auto triggered"
+    public String dir
     public String eventMatch
     public String overrideBranch
     public String overrideCommit
@@ -70,34 +72,59 @@ abstract class BoxBase<T extends CommonConfigBase> implements Serializable {
         return "common"
     }
 
+    def wrapDir(Closure closure) {
+        if (dir) {
+            return Config.pipeline.dir(dir) {
+                closure()
+            }
+        }
+        return closure()
+    }
+
     def wrap(Closure closure) {
         try {
             Config.pipeline = closure.thisObject
-            Config.pipeline.stage("Initialize") {
-                init()
-                setDescription()
-            }
-            closure()
-            Config.pipeline.stage("Summary") {
-                runTriggers()
-                success()
-                summary()
+            Config.pipeline.stage("Checkout") {
+                checkoutScm()
             }
         } catch (Exception ex) {
             if (config) {
                 failure(ex)
             }
             throw ex
-        } finally {
-            if (config) {
-                Config.pipeline.stage("Cleanup") {
-                    cleanup()
+        }
+        wrapDir {
+            try {
+                Config.pipeline = closure.thisObject
+                Config.pipeline.stage("Init") {
+                    init()
+                    setDescription()
+                }
+                closure()
+                Config.pipeline.stage("Summary") {
+                    runTriggers()
+                    success()
+                    summary()
+                }
+            } catch (Exception ex) {
+                if (config) {
+                    failure(ex)
+                }
+                throw ex
+            } finally {
+                if (config) {
+                    Config.pipeline.stage("Cleanup") {
+                        cleanup()
+                    }
                 }
             }
         }
     }
 
-    def init() {
+    def checkoutScm() {
+        // set the scm directory
+        Config.scmDir = Utils.toAbsolutePath(".")
+
         // load the global config
         String configYaml = Config.pipeline.libraryResource(globalConfigPath)
         def globalConfig = new GlobalConfig().newFromYaml(configYaml)
@@ -146,6 +173,11 @@ abstract class BoxBase<T extends CommonConfigBase> implements Serializable {
                 buildUser = "started by ${cause.getUserName()}"
             }
         }
+    }
+
+    def init() {
+        // set the base directory
+        Config.baseDir = Utils.toAbsolutePath(".")
 
         // create directory for shared library
         Config.pipeline.sh """

--- a/src/com/boxboat/jenkins/pipeline/BoxBase.groovy
+++ b/src/com/boxboat/jenkins/pipeline/BoxBase.groovy
@@ -186,18 +186,16 @@ abstract class BoxBase<T extends CommonConfigBase> implements Serializable {
         """
 
         // merge config from jenkins.yaml if exists
-        def configFile = Config.pipeline.sh(returnStdout: true, script: """
-            set +x
-            for f in "jenkins.yml" "jenkins.yaml"; do
-                if [ -f "\$f" ]; then
-                    echo  "\$f"
-                    break
-                fi
-            done
-        """)?.trim()
+        String configFile = null
+        if (Config.pipeline.fileExists("jenkins.yaml")) {
+            configFile = "jenkins.yaml"
+        } else if (Config.pipeline.fileExists("jenkins.yml")) {
+            configFile = "jenkins.yml"
+        }
         if (configFile) {
             String configFileContents = Config.pipeline.readFile(configFile)
             def configFileObj = new RepoConfig().newFromYaml(configFileContents)
+            def configKey = configKey()
             if (configKey != "common") {
                 config.merge(configFileObj.common)
             }

--- a/test-resources/com/boxboat/jenkins/test/pipeline/build.jenkins
+++ b/test-resources/com/boxboat/jenkins/test/pipeline/build.jenkins
@@ -5,6 +5,7 @@ import com.boxboat.jenkins.pipeline.build.*
 def execute() {
 
     def build = new BoxBuild(
+        dir: "./test",
         globalConfigPath: "com/boxboat/jenkins/config.example.yaml",
         config: [
             composeProfileMap: [

--- a/test/com/boxboat/jenkins/test/pipeline/PipelineBase.groovy
+++ b/test/com/boxboat/jenkins/test/pipeline/PipelineBase.groovy
@@ -14,6 +14,9 @@ abstract class PipelineBase extends BasePipelineTest {
         helper.registerAllowedMethod('fileExists', [String.class], { fileName ->
             return false
         })
+        helper.registerAllowedMethod('pwd', [], {
+            return System.getProperty('java.io.tmpdir')
+        })
         helper.registerAllowedMethod('error', [String.class], { error ->
             throw new Exception(error)
         })

--- a/test/com/boxboat/jenkins/test/pipeline/deploy/kubernetes/KubePodTest.groovy
+++ b/test/com/boxboat/jenkins/test/pipeline/deploy/kubernetes/KubePodTest.groovy
@@ -10,17 +10,17 @@ class KubePodTest {
     @Test
     void testKubeLogs() {
         def kubeLogs = KubePod.pollScript(outFile: "out.log", namespace: "test-ns", container: "nginx", labels: "a=b,c=d")
-        assertEquals(kubeLogs.trim(), """
-            ./sharedLibraryScripts/pod-logs.sh -o "out.log" -n "test-ns" -l "a=b,c=d" -c "nginx"
-        """.trim())
+        assertEquals("""
+            ${System.getProperty('java.io.tmpdir')}/sharedLibraryScripts/pod-logs.sh -o "out.log" -n "test-ns" -l "a=b,c=d" -c "nginx"
+        """.trim(), kubeLogs.trim())
     }
 
     @Test
     void testKubeExec() {
         def kubeExec = KubePod.execScript(namespace: "test-ns", labels: "a=b,c=d", container: "nginx", command: ["cat", "test.yaml"])
-        assertEquals(kubeExec.trim(), """
-            ./sharedLibraryScripts/pod-exec.sh -n "test-ns" -l "a=b,c=d" -c "nginx" "cat" "test.yaml"
-        """.trim())
+        assertEquals("""
+            ${System.getProperty('java.io.tmpdir')}/sharedLibraryScripts/pod-exec.sh -n "test-ns" -l "a=b,c=d" -c "nginx" "cat" "test.yaml"
+        """.trim(), kubeExec.trim())
     }
 
 }


### PR DESCRIPTION
Currently relative paths are used in `GitRepo` and `LibraryScript` that do not handle changing directories well

This PR adds the `dir` property to `BoxBase`, and changes directory into `dir` after SCM checkout.  It introduces a `Checkout` stage that runs first, and the rest of the stages called in `wrap()` are now executed inside the `dir`