### PR TITLE
BoxBuild: clean event after passing to config.getEventRegistries

### DIFF
--- a/src/com/boxboat/jenkins/library/Utils.groovy
+++ b/src/com/boxboat/jenkins/library/Utils.groovy
@@ -6,17 +6,6 @@ import java.nio.file.Paths
 
 class Utils implements Serializable {
 
-    static String cleanEvent(String event) {
-        if (event == null) {
-            return null
-        }
-        def eventSplit = event.split("/", 2)
-        if (eventSplit.size() > 1) {
-            eventSplit[1] = cleanTag(eventSplit[1])
-        }
-        return eventSplit.join("/")
-    }
-
     static String cleanTag(String tag) {
         if (tag == null) {
             return null

--- a/src/com/boxboat/jenkins/library/config/CommonConfigBase.groovy
+++ b/src/com/boxboat/jenkins/library/config/CommonConfigBase.groovy
@@ -25,13 +25,8 @@ class CommonConfigBase<T> extends BaseConfig<T> {
                     registries.add(Config.global.getRegistry(eventRegistryKey.registryKey))
                 }
             } else if (eventRegistryKey.eventRegex) {
-                Boolean matches = false
-                def closure = {
-                    def matcher = event =~ eventRegistryKey.eventRegex
-                    matches = matcher.matches()
-                }
-                closure()
-                if (matches) {
+                def matcher = event =~ eventRegistryKey.eventRegex
+                if (matcher.matches()) {
                     registries.add(Config.global.getRegistry(eventRegistryKey.registryKey))
                 }
             }

--- a/src/com/boxboat/jenkins/pipeline/build/BoxBuild.groovy
+++ b/src/com/boxboat/jenkins/pipeline/build/BoxBuild.groovy
@@ -60,8 +60,8 @@ class BoxBuild extends BoxBase<BuildConfig> implements Serializable {
     }
 
     def push() {
-        def branch = gitRepo.branch?.toLowerCase()
-        def event = Utils.cleanEvent("commit/${branch}")
+        def branch = gitRepo.getBranch()
+        def event = "commit/${branch}"
         def eventTag = Utils.cleanTag(event)
         Config.pipeline.echo branch
         def buildTag = "build-${gitRepo.shortHash}"
@@ -69,7 +69,7 @@ class BoxBuild extends BoxBase<BuildConfig> implements Serializable {
 
         if (registries) {
             def isBranchTip = gitRepo.isBranchTip()
-            def tags = [buildTag]
+            def tags = [buildTag.toString()]
             if (isBranchTip) {
                 tags.add(eventTag)
             }

--- a/src/com/boxboat/jenkins/pipeline/deploy/BoxDeploy.groovy
+++ b/src/com/boxboat/jenkins/pipeline/deploy/BoxDeploy.groovy
@@ -66,7 +66,6 @@ class BoxDeploy extends BoxBase<DeployConfig> implements Serializable {
                     if (!this.triggerEvent) {
                         Config.pipeline.error "'triggerEvent' must be set for this deployment"
                     }
-                    this.triggerEvent = Utils.cleanEvent(this.triggerEvent)
                     Boolean matches = false
                     def closure = {
                         def matcher = this.triggerEvent =~ deployment.eventRegex


### PR DESCRIPTION
Previously cleaned events were passed to `config.getEventRegistries()`, potentially causing an issue with matching against `eventRegex`