### PR TITLE
Fixing variable name

### DIFF
--- a/docs/pipelines/box-promote.md
+++ b/docs/pipelines/box-promote.md
@@ -27,7 +27,7 @@ promote:
 @Library('jenkins-shared-library@master')
 import com.boxboat.jenkins.pipeline.promote.*
 
-def promotions = ["", "stage", "prod"]
+def deployments = ["", "stage", "prod"]
 properties([
   parameters([
     choice(name: 'promotionKey', choices: deployments, description: 'Promotion', defaultValue: '')


### PR DESCRIPTION
We used "deployments" in the choices and need to set the variable name to the same.