### PR TITLE
#25 Add image change checking prior to incrementing semver

### DIFF
--- a/src/com/boxboat/jenkins/library/git/GitRepo.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitRepo.groovy
@@ -64,7 +64,7 @@ class GitRepo implements Serializable {
             cd "${this.dir}"
             git show-ref --hash=${shortHashLength} -s ${tag}  || :
         """)?.trim()
-        return Utils.resultOrTest(result, "0123456789abcdef0123456789abcdef")
+        return Utils.resultOrTest(result, "0123456789abcdef0123456789abcdef".substring(shortHashLength))
     }
 
     boolean isBranchTip() {

--- a/src/com/boxboat/jenkins/library/git/GitRepo.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitRepo.groovy
@@ -8,6 +8,8 @@ class GitRepo implements Serializable {
     public checkoutData = [:]
     public dir
 
+    private shortHashLength = 12
+
     String getHash() {
         return Utils.resultOrTest(Config.pipeline.sh(returnStdout: true, script: """
             cd "${this.dir}"
@@ -16,7 +18,7 @@ class GitRepo implements Serializable {
     }
 
     String getShortHash() {
-        return getHash()?.substring(0, 12)
+        return getHash()?.substring(0, shortHashLength)
     }
 
     String _branch
@@ -55,6 +57,14 @@ class GitRepo implements Serializable {
 
     String getBranchUrl() {
         return Config.global.git.getBranchUrl(getRemotePath(), getBranch())
+    }
+
+    String getTagReferenceHash(String tag) {
+        def result = Config.pipeline.sh(returnStdout: true, script: """
+            cd "${this.dir}"
+            git show-ref --hash=${shortHashLength} -s ${tag}  || :
+        """)?.trim()
+        return Utils.resultOrTest(result, "0123456789abcdef0123456789abcdef")
     }
 
     boolean isBranchTip() {

--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -125,7 +125,8 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
         }
 
         if (!config.gitTagDisable && (gitCommitToTag || gitTagToTag)) {
-            if (gitRepo.getTagReferenceHash(currSemVer.toString()) == gitCommitToTag) {
+            if (gitRepo.getTagReferenceHash(currSemVer.toString()) == gitCommitToTag ||
+                    gitRepo.getTagReferenceHash(currSemVer.toString()) == gitRepo.getTagReferenceHash(gitTagToTag)) {
                 versionChange = false
                 Config.pipeline.echo "No version changes detected"
             }


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

For `dockhand` configurations where git tagging is being utilized check the current semantic version prior to incrementing to see if it is pointing to the same git hash that the promotion pipeline is preparing to assign to the next version

Closes #25 