### PR TITLE
Clean commit-<branch> tags for branches removed from git

### DIFF
--- a/src/com/boxboat/jenkins/library/config/Config.groovy
+++ b/src/com/boxboat/jenkins/library/config/Config.groovy
@@ -1,5 +1,8 @@
 package com.boxboat.jenkins.library.config
 
+import com.boxboat.jenkins.library.buildVersions.GitBuildVersions
+import com.boxboat.jenkins.library.git.GitAccount
+
 class Config implements Serializable {
 
     static String baseDir = "./"
@@ -14,6 +17,22 @@ class Config implements Serializable {
 
     static <T extends CommonConfigBase> T castRepo() {
         return (T) repo
+    }
+
+    static GitAccount gitAccount = new GitAccount()
+
+    private static GitBuildVersions _buildVersions
+
+    static GitBuildVersions getBuildVersions() {
+        if (!_buildVersions) {
+            _buildVersions = new GitBuildVersions()
+            _buildVersions.checkout()
+        }
+        return _buildVersions
+    }
+
+    static resetBuildVersions() {
+        _buildVersions = null
     }
 
 }

--- a/src/com/boxboat/jenkins/library/docker/DTRClean.groovy
+++ b/src/com/boxboat/jenkins/library/docker/DTRClean.groovy
@@ -27,36 +27,36 @@ class DTRClean implements Serializable {
 
         return Utils.resultOrTest(repositories, [
                 "repositories": [
-                    [
-                      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                      "namespace": "apps",
-                      "namespaceType": "organization",
-                      "name": "test1",
-                      "shortDescription": "",
-                      "visibility": "private",
-                      "scanOnPush": false,
-                      "immutableTags": false,
-                      "enableManifestLists": false,
-                      "pulls": 5,
-                      "pushes": 5,
-                      "tagLimit": 0
-                    ],
-                    [
-                      "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-                      "namespace": "apps",
-                      "namespaceType": "organization",
-                      "name": "test2",
-                      "shortDescription": "",
-                      "visibility": "private",
-                      "scanOnPush": false,
-                      "immutableTags": false,
-                      "enableManifestLists": false,
-                      "pulls": 5,
-                      "pushes": 5,
-                      "tagLimit": 0
-                    ]
+                        [
+                                "id"                 : "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                                "namespace"          : "apps",
+                                "namespaceType"      : "organization",
+                                "name"               : "test1",
+                                "shortDescription"   : "",
+                                "visibility"         : "private",
+                                "scanOnPush"         : false,
+                                "immutableTags"      : false,
+                                "enableManifestLists": false,
+                                "pulls"              : 5,
+                                "pushes"             : 5,
+                                "tagLimit"           : 0
+                        ],
+                        [
+                                "id"                 : "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                                "namespace"          : "apps",
+                                "namespaceType"      : "organization",
+                                "name"               : "test2",
+                                "shortDescription"   : "",
+                                "visibility"         : "private",
+                                "scanOnPush"         : false,
+                                "immutableTags"      : false,
+                                "enableManifestLists": false,
+                                "pulls"              : 5,
+                                "pushes"             : 5,
+                                "tagLimit"           : 0
+                        ]
                 ]
-            ])
+        ])
     }
 
     List<Map<String, Object>> readRepositoryTags(Registry registry, String namespace, String name) {
@@ -74,71 +74,71 @@ class DTRClean implements Serializable {
         }
 
         return Utils.resultOrTest(tags, [
-              [
-                "name": "commit-test",
-                "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "author": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "updatedAt": "2018-12-01T00:00:00.000Z",
-                "createdAt": "2018-12-01T00:00:00.000Z",
-                "hashMismatch": false,
-                "inNotary": false,
-                "manifest": [
-                  "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-                  "configMediaType": "application/vnd.docker.container.image.v1+json",
-                  "size": 100,
-                  "createdAt": "2018-12-01T00:00:00.000Z"
+                [
+                        "name"        : "commit-test",
+                        "digest"      : "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "author"      : "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                        "updatedAt"   : "2018-12-01T00:00:00.000Z",
+                        "createdAt"   : "2018-12-01T00:00:00.000Z",
+                        "hashMismatch": false,
+                        "inNotary"    : false,
+                        "manifest"    : [
+                                "digest"         : "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                "mediaType"      : "application/vnd.docker.distribution.manifest.v2+json",
+                                "configMediaType": "application/vnd.docker.container.image.v1+json",
+                                "size"           : 100,
+                                "createdAt"      : "2018-12-01T00:00:00.000Z"
+                        ]
+                ],
+                [
+                        "name"        : "build-aaaaaaaaaaaa",
+                        "digest"      : "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "author"      : "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                        "updatedAt"   : "2018-12-01T00:00:00.000Z",
+                        "createdAt"   : "2018-12-01T00:00:00.000Z",
+                        "hashMismatch": false,
+                        "inNotary"    : false,
+                        "manifest"    : [
+                                "digest"         : "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                "mediaType"      : "application/vnd.docker.distribution.manifest.v2+json",
+                                "configMediaType": "application/vnd.docker.container.image.v1+json",
+                                "size"           : 100,
+                                "createdAt"      : "2018-12-01T00:00:00.000Z"
+                        ]
+                ],
+                [
+                        "name"        : "build-bbbbbbbbbbbb",
+                        "digest"      : "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "author"      : "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                        "updatedAt"   : "2018-12-01T00:00:00.000Z",
+                        "createdAt"   : "2018-12-01T00:00:00.000Z",
+                        "hashMismatch": false,
+                        "inNotary"    : false,
+                        "manifest"    : [
+                                "digest"         : "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                                "mediaType"      : "application/vnd.docker.distribution.manifest.v2+json",
+                                "configMediaType": "application/vnd.docker.container.image.v1+json",
+                                "size"           : 100,
+                                "createdAt"      : "2018-12-01T00:00:00.000Z"
+                        ]
+                ],
+                [
+                        "name"        : "build-cccccccccccc",
+                        "digest"      : "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "author"      : "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                        "updatedAt"   : "2018-12-01T00:00:00.000Z",
+                        "createdAt"   : "2018-12-01T00:00:00.000Z",
+                        "hashMismatch": false,
+                        "inNotary"    : false,
+                        "manifest"    : [
+                                "digest"         : "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                                "mediaType"      : "application/vnd.docker.distribution.manifest.v2+json",
+                                "configMediaType": "application/vnd.docker.container.image.v1+json",
+                                "size"           : 100,
+                                "createdAt"      : "2018-12-01T00:00:00.000Z"
+                        ]
                 ]
-              ],
-              [
-                "name": "build-aaaaaaaaaaaa",
-                "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "author": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "updatedAt": "2018-12-01T00:00:00.000Z",
-                "createdAt": "2018-12-01T00:00:00.000Z",
-                "hashMismatch": false,
-                "inNotary": false,
-                "manifest": [
-                  "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-                  "configMediaType": "application/vnd.docker.container.image.v1+json",
-                  "size": 100,
-                  "createdAt": "2018-12-01T00:00:00.000Z"
-                ]
-              ],
-              [
-                "name": "build-bbbbbbbbbbbb",
-                "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "author": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-                "updatedAt": "2018-12-01T00:00:00.000Z",
-                "createdAt": "2018-12-01T00:00:00.000Z",
-                "hashMismatch": false,
-                "inNotary": false,
-                "manifest": [
-                  "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-                  "configMediaType": "application/vnd.docker.container.image.v1+json",
-                  "size": 100,
-                  "createdAt": "2018-12-01T00:00:00.000Z"
-                ]
-              ],
-              [
-                "name": "build-cccccccccccc",
-                "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "author": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-                "updatedAt": "2018-12-01T00:00:00.000Z",
-                "createdAt": "2018-12-01T00:00:00.000Z",
-                "hashMismatch": false,
-                "inNotary": false,
-                "manifest": [
-                  "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-                  "configMediaType": "application/vnd.docker.container.image.v1+json",
-                  "size": 100,
-                  "createdAt": "2018-12-01T00:00:00.000Z"
-                ]
-              ]
-            ])
+        ])
     }
 
     int deleteTag(Registry registry, String namespace, String name, String tag) {
@@ -181,7 +181,7 @@ class DTRClean implements Serializable {
 
             def registryRepositoryTags = readRepositoryTags(registry, namespace, name)
 
-            def imageManifests = new ImageManifests()
+            def imageManifests = new ImageManifests(new Image(path: "${name}/${namespace}"))
             registryRepositoryTags.each { registryRepositoryTag ->
                 imageManifests.addDtrManifest(registryRepositoryTag)
             }

--- a/src/com/boxboat/jenkins/library/docker/HarborRegistryClean.groovy
+++ b/src/com/boxboat/jenkins/library/docker/HarborRegistryClean.groovy
@@ -18,11 +18,11 @@ class HarborRegistryClean implements Serializable {
         return requestPaginated(registry, "/projects", projectPageSize)
     }
 
-    List<Map<String, Object>>  requestRepositories(Registry registry, String projectId) {
-        return requestPaginated(registry, "/repositories", repositoryPageSize,  ["project_id": projectId])
+    List<Map<String, Object>> requestRepositories(Registry registry, String projectId) {
+        return requestPaginated(registry, "/repositories", repositoryPageSize, ["project_id": projectId])
     }
 
-    List<Map<String, Object>>  readRepositories(Registry registry) {
+    List<Map<String, Object>> readRepositories(Registry registry) {
 
         def projects = requestProjects(registry)
 
@@ -36,34 +36,34 @@ class HarborRegistryClean implements Serializable {
         }
 
         return Utils.resultOrTest(repositories,
-            [
                 [
-                    "id" : "1",
-                    "project_id" : "1",
-                    "name" : "test1",
-                    "description" : "",
-                    "creation_time" : "2019-01-01T16:00:00Z",
-                    "update_time" : "2019-01-01T16:00:00Z",
-                    "labels" : [],
-                    "tags_count" : "1",
-                    "star_count" : "0",
-                ],
-                [
-                    "id" : "2",
-                    "project_id" : "2",
-                    "name" : "test2",
-                    "description" : "",
-                    "creation_time" : "2019-01-01T16:00:00Z",
-                    "update_time" : "2019-01-01T16:00:00Z",
-                    "labels" : [],
-                    "tags_count" : "1",
-                    "star_count" : "0",
-                ],
-            ]
+                        [
+                                "id"           : "1",
+                                "project_id"   : "1",
+                                "name"         : "test1",
+                                "description"  : "",
+                                "creation_time": "2019-01-01T16:00:00Z",
+                                "update_time"  : "2019-01-01T16:00:00Z",
+                                "labels"       : [],
+                                "tags_count"   : "1",
+                                "star_count"   : "0",
+                        ],
+                        [
+                                "id"           : "2",
+                                "project_id"   : "2",
+                                "name"         : "test2",
+                                "description"  : "",
+                                "creation_time": "2019-01-01T16:00:00Z",
+                                "update_time"  : "2019-01-01T16:00:00Z",
+                                "labels"       : [],
+                                "tags_count"   : "1",
+                                "star_count"   : "0",
+                        ],
+                ]
         )
     }
 
-    List<Object> readRepositoryTags(Registry registry, String name) {
+    List<Map<String, Object>> readRepositoryTags(Registry registry, String name) {
         def requestURI = registry.getRegistryUrl() + registryAPIBase + "/repositories/${name}/tags"
         def result = Config.pipeline.httpRequest(
                 url: requestURI,
@@ -76,199 +76,199 @@ class HarborRegistryClean implements Serializable {
             tags = Config.pipeline.readJSON(text: result.toString())
         }
         return Utils.resultOrTest(tags, [
-              [
-                "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "name": "build-aaaaaaaaaaaa",
-                "size": 232664445,
-                "architecture": "amd64",
-                "os": "linux",
-                "os.version": "",
-                "docker_version": "18.06.1-ce",
-                "author": "",
-                "created": "2019-09-09T19:41:11.917513133Z",
-                "config": [
-                  "labels": []
+                [
+                        "digest"        : "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "name"          : "build-aaaaaaaaaaaa",
+                        "size"          : 232664445,
+                        "architecture"  : "amd64",
+                        "os"            : "linux",
+                        "os.version"    : "",
+                        "docker_version": "18.06.1-ce",
+                        "author"        : "",
+                        "created"       : "2019-09-09T19:41:11.917513133Z",
+                        "config"        : [
+                                "labels": []
+                        ],
+                        "signature"     : null,
+                        "scan_overview" : [
+                                "image_digest" : "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                "scan_status"  : "finished",
+                                "job_id"       : 407,
+                                "severity"     : 5,
+                                "components"   : [
+                                        "total"  : 111,
+                                        "summary": [
+                                                [
+                                                        "severity": 1,
+                                                        "count"   : 76
+                                                ],
+                                                [
+                                                        "severity": 5,
+                                                        "count"   : 12
+                                                ],
+                                                [
+                                                        "severity": 4,
+                                                        "count"   : 17
+                                                ],
+                                                [
+                                                        "severity": 3,
+                                                        "count"   : 6
+                                                ]
+                                        ]
+                                ],
+                                "details_key"  : "9250d0e8bf02011810a2fcc85ee87567fde1e0f09fe3548a138ee20e9196a034",
+                                "creation_time": "2019-09-10T00:00:02.706191Z",
+                                "update_time"  : "2019-10-02T00:00:04.812058Z"
+                        ],
+                        "labels"        : [],
+                        "push_time"     : "2019-09-20T12:25:36.423777Z",
+                        "pull_time"     : "0001-01-01T00:00:00Z"
                 ],
-                "signature": null,
-                "scan_overview": [
-                  "image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                  "scan_status": "finished",
-                  "job_id": 407,
-                  "severity": 5,
-                  "components": [
-                    "total": 111,
-                    "summary": [
-                      [
-                        "severity": 1,
-                        "count": 76
-                      ],
-                      [
-                        "severity": 5,
-                        "count": 12
-                      ],
-                      [
-                        "severity": 4,
-                        "count": 17
-                      ],
-                      [
-                        "severity": 3,
-                        "count": 6
-                      ]
-                    ]
-                  ],
-                  "details_key": "9250d0e8bf02011810a2fcc85ee87567fde1e0f09fe3548a138ee20e9196a034",
-                  "creation_time": "2019-09-10T00:00:02.706191Z",
-                  "update_time": "2019-10-02T00:00:04.812058Z"
+                [
+                        "digest"        : "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "name"          : "commit-test",
+                        "size"          : 232664445,
+                        "architecture"  : "amd64",
+                        "os"            : "linux",
+                        "os.version"    : "",
+                        "docker_version": "18.06.1-ce",
+                        "author"        : "",
+                        "created"       : "2019-09-09T19:41:11.917513133Z",
+                        "config"        : [
+                                "labels": []
+                        ],
+                        "signature"     : null,
+                        "scan_overview" : [
+                                "image_digest" : "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                "scan_status"  : "finished",
+                                "job_id"       : 407,
+                                "severity"     : 5,
+                                "components"   : [
+                                        "total"  : 111,
+                                        "summary": [
+                                                [
+                                                        "severity": 1,
+                                                        "count"   : 76
+                                                ],
+                                                [
+                                                        "severity": 5,
+                                                        "count"   : 12
+                                                ],
+                                                [
+                                                        "severity": 4,
+                                                        "count"   : 17
+                                                ],
+                                                [
+                                                        "severity": 3,
+                                                        "count"   : 6
+                                                ]
+                                        ]
+                                ],
+                                "details_key"  : "9250d0e8bf02011810a2fcc85ee87567fde1e0f09fe3548a138ee20e9196a034",
+                                "creation_time": "2019-09-10T00:00:02.706191Z",
+                                "update_time"  : "2019-10-02T00:00:04.812058Z"
+                        ],
+                        "labels"        : [],
+                        "push_time"     : "2019-09-20T12:25:36.423777Z",
+                        "pull_time"     : "0001-01-01T00:00:00Z"
                 ],
-                "labels": [],
-                "push_time": "2019-09-20T12:25:36.423777Z",
-                "pull_time": "0001-01-01T00:00:00Z"
-              ],
-              [
-                "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "name": "commit-test",
-                "size": 232664445,
-                "architecture": "amd64",
-                "os": "linux",
-                "os.version": "",
-                "docker_version": "18.06.1-ce",
-                "author": "",
-                "created": "2019-09-09T19:41:11.917513133Z",
-                "config": [
-                  "labels": []
+                [
+                        "digest"        : "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "name"          : "commit-bbbbbbbbbbbb",
+                        "size"          : 232664445,
+                        "architecture"  : "amd64",
+                        "os"            : "linux",
+                        "os.version"    : "",
+                        "docker_version": "18.06.1-ce",
+                        "author"        : "",
+                        "created"       : "2019-09-09T19:41:11.917513133Z",
+                        "config"        : [
+                                "labels": []
+                        ],
+                        "signature"     : null,
+                        "scan_overview" : [
+                                "image_digest" : "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                                "scan_status"  : "finished",
+                                "job_id"       : 407,
+                                "severity"     : 5,
+                                "components"   : [
+                                        "total"  : 111,
+                                        "summary": [
+                                                [
+                                                        "severity": 1,
+                                                        "count"   : 76
+                                                ],
+                                                [
+                                                        "severity": 5,
+                                                        "count"   : 12
+                                                ],
+                                                [
+                                                        "severity": 4,
+                                                        "count"   : 17
+                                                ],
+                                                [
+                                                        "severity": 3,
+                                                        "count"   : 6
+                                                ]
+                                        ]
+                                ],
+                                "details_key"  : "9250d0e8bf02011810a2fcc85ee87567fde1e0f09fe3548a138ee20e9196a034",
+                                "creation_time": "2019-09-10T00:00:02.706191Z",
+                                "update_time"  : "2019-10-02T00:00:04.812058Z"
+                        ],
+                        "labels"        : [],
+                        "push_time"     : "2019-09-20T12:25:36.423777Z",
+                        "pull_time"     : "0001-01-01T00:00:00Z"
                 ],
-                "signature": null,
-                "scan_overview": [
-                  "image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                  "scan_status": "finished",
-                  "job_id": 407,
-                  "severity": 5,
-                  "components": [
-                    "total": 111,
-                    "summary": [
-                      [
-                        "severity": 1,
-                        "count": 76
-                      ],
-                      [
-                        "severity": 5,
-                        "count": 12
-                      ],
-                      [
-                        "severity": 4,
-                        "count": 17
-                      ],
-                      [
-                        "severity": 3,
-                        "count": 6
-                      ]
-                    ]
-                  ],
-                  "details_key": "9250d0e8bf02011810a2fcc85ee87567fde1e0f09fe3548a138ee20e9196a034",
-                  "creation_time": "2019-09-10T00:00:02.706191Z",
-                  "update_time": "2019-10-02T00:00:04.812058Z"
-                ],
-                "labels": [],
-                "push_time": "2019-09-20T12:25:36.423777Z",
-                "pull_time": "0001-01-01T00:00:00Z"
-              ],
-              [
-                "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "name": "commit-bbbbbbbbbbbb",
-                "size": 232664445,
-                "architecture": "amd64",
-                "os": "linux",
-                "os.version": "",
-                "docker_version": "18.06.1-ce",
-                "author": "",
-                "created": "2019-09-09T19:41:11.917513133Z",
-                "config": [
-                  "labels": []
-                ],
-                "signature": null,
-                "scan_overview": [
-                  "image_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                  "scan_status": "finished",
-                  "job_id": 407,
-                  "severity": 5,
-                  "components": [
-                    "total": 111,
-                    "summary": [
-                      [
-                        "severity": 1,
-                        "count": 76
-                      ],
-                      [
-                        "severity": 5,
-                        "count": 12
-                      ],
-                      [
-                        "severity": 4,
-                        "count": 17
-                      ],
-                      [
-                        "severity": 3,
-                        "count": 6
-                      ]
-                    ]
-                  ],
-                  "details_key": "9250d0e8bf02011810a2fcc85ee87567fde1e0f09fe3548a138ee20e9196a034",
-                  "creation_time": "2019-09-10T00:00:02.706191Z",
-                  "update_time": "2019-10-02T00:00:04.812058Z"
-                ],
-                "labels": [],
-                "push_time": "2019-09-20T12:25:36.423777Z",
-                "pull_time": "0001-01-01T00:00:00Z"
-              ],
-              [
-                "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                "name": "commit-cccccccccccc",
-                "size": 232664445,
-                "architecture": "amd64",
-                "os": "linux",
-                "os.version": "",
-                "docker_version": "18.06.1-ce",
-                "author": "",
-                "created": "2019-09-09T19:41:11.917513133Z",
-                "config": [
-                  "labels": []
-                ],
-                "signature": null,
-                "scan_overview": [
-                  "image_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                  "scan_status": "finished",
-                  "job_id": 407,
-                  "severity": 5,
-                  "components": [
-                    "total": 111,
-                    "summary": [
-                      [
-                        "severity": 1,
-                        "count": 76
-                      ],
-                      [
-                        "severity": 5,
-                        "count": 12
-                      ],
-                      [
-                        "severity": 4,
-                        "count": 17
-                      ],
-                      [
-                        "severity": 3,
-                        "count": 6
-                      ]
-                    ]
-                  ],
-                  "details_key": "9250d0e8bf02011810a2fcc85ee87567fde1e0f09fe3548a138ee20e9196a034",
-                  "creation_time": "2019-09-10T00:00:02.706191Z",
-                  "update_time": "2019-10-02T00:00:04.812058Z"
-                ],
-                "labels": [],
-                "push_time": "2019-09-20T12:25:36.423777Z",
-                "pull_time": "0001-01-01T00:00:00Z"
-              ]
-            ])
+                [
+                        "digest"        : "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                        "name"          : "commit-cccccccccccc",
+                        "size"          : 232664445,
+                        "architecture"  : "amd64",
+                        "os"            : "linux",
+                        "os.version"    : "",
+                        "docker_version": "18.06.1-ce",
+                        "author"        : "",
+                        "created"       : "2019-09-09T19:41:11.917513133Z",
+                        "config"        : [
+                                "labels": []
+                        ],
+                        "signature"     : null,
+                        "scan_overview" : [
+                                "image_digest" : "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                                "scan_status"  : "finished",
+                                "job_id"       : 407,
+                                "severity"     : 5,
+                                "components"   : [
+                                        "total"  : 111,
+                                        "summary": [
+                                                [
+                                                        "severity": 1,
+                                                        "count"   : 76
+                                                ],
+                                                [
+                                                        "severity": 5,
+                                                        "count"   : 12
+                                                ],
+                                                [
+                                                        "severity": 4,
+                                                        "count"   : 17
+                                                ],
+                                                [
+                                                        "severity": 3,
+                                                        "count"   : 6
+                                                ]
+                                        ]
+                                ],
+                                "details_key"  : "9250d0e8bf02011810a2fcc85ee87567fde1e0f09fe3548a138ee20e9196a034",
+                                "creation_time": "2019-09-10T00:00:02.706191Z",
+                                "update_time"  : "2019-10-02T00:00:04.812058Z"
+                        ],
+                        "labels"        : [],
+                        "push_time"     : "2019-09-20T12:25:36.423777Z",
+                        "pull_time"     : "0001-01-01T00:00:00Z"
+                ]
+        ])
     }
 
     int deleteTag(Registry registry, String name, String tag) {
@@ -309,9 +309,9 @@ class HarborRegistryClean implements Serializable {
 
                 Config.pipeline.echo "Reading ${name}"
 
-                def registryRepositoryTags =readRepositoryTags(registry, name)
+                def registryRepositoryTags = readRepositoryTags(registry, name)
 
-                def imageManifests = new ImageManifests()
+                def imageManifests = new ImageManifests(new Image(path: name))
                 registryRepositoryTags.each { registryRepositoryTag ->
                     imageManifests.addHarborManifest(registryRepositoryTag)
                 }
@@ -329,17 +329,17 @@ class HarborRegistryClean implements Serializable {
             Map<String, String> query = [:]) {
 
         def requestURL = registry.getRegistryUrl() + registryAPIBase + path
-        query["page_size"] =  pageSize.toString()
+        query["page_size"] = pageSize.toString()
 
         def result = []
         def pResultCount = pageSize
 
-        for(def page = 1; pResultCount == pageSize; page++) {
+        for (def page = 1; pResultCount == pageSize; page++) {
             def paginatedQuery = query.clone()
             paginatedQuery["page"] = page.toString()
 
             def pResponse = Config.pipeline.httpRequest(
-                    url: requestURL + "?" + paginatedQuery.collect{ k,v -> "$k=$v" }.join('&'),
+                    url: requestURL + "?" + paginatedQuery.collect { k, v -> "$k=$v" }.join('&'),
                     authentication: registry.credential,
                     httpMode: 'GET',
                     contentType: "APPLICATION_JSON"

--- a/src/com/boxboat/jenkins/library/docker/ImageManifest.groovy
+++ b/src/com/boxboat/jenkins/library/docker/ImageManifest.groovy
@@ -18,7 +18,11 @@ class ImageManifest implements Serializable {
         return (now - imageAge) / secsToDays
     }
 
-    boolean isCommitHash() {
+    boolean isCommitHashTag() {
         return tag.matches(/(?i)^build-[0-9a-f]{12}$/)
+    }
+
+    boolean isBranchTag() {
+        return tag.startsWith("commit-")
     }
 }

--- a/src/com/boxboat/jenkins/library/docker/ImageManifests.groovy
+++ b/src/com/boxboat/jenkins/library/docker/ImageManifests.groovy
@@ -1,10 +1,19 @@
 package com.boxboat.jenkins.library.docker
 
+import com.boxboat.jenkins.library.Utils
+import com.boxboat.jenkins.library.buildVersions.GitBuildVersions
 import com.boxboat.jenkins.library.config.Config
+import com.boxboat.jenkins.library.git.GitRepo
 
 class ImageManifests implements Serializable {
 
     Map<String, List<ImageManifest>> manifests = [:]
+
+    Image image
+
+    ImageManifests(Image image) {
+        this.image = image
+    }
 
     def addDtrManifest(manifest) {
         if (DtrImageManifest.isValid(manifest)) {
@@ -34,15 +43,30 @@ class ImageManifests implements Serializable {
         Date now = new Date()
         long nowSec = now.getTime()
 
+        // would be nice to use a set here but I think Jenkins doesn't like sets
+        Map<String, String> branchMap
+
+        GitBuildVersions buildVersions = Config.getBuildVersions()
+        def gitRepoPath = buildVersions.getImageRepoPath(image)
+        if (gitRepoPath) {
+            try {
+                branchMap = GitRepo.remoteBranches(Config.global.git.getRemoteUrl(gitRepoPath)).collectEntries { it ->
+                    [(Utils.cleanTag("commit/${it}")): it]
+                }
+            } catch (Exception ignored) {
+                // the git remote may have moved
+            }
+        }
+
         List<String> cleanableTagsList = []
         manifests.keySet().toList().each { key ->
             def imageManifests = manifests[key]
-            def commitHashManifests = imageManifests.findAll {
-                manifest -> manifest.isCommitHash()
+            def candidateManifests = imageManifests.findAll { manifest ->
+                manifest.isCommitHashTag() || (branchMap != null && manifest.isBranchTag() && !branchMap.containsKey(manifest.tag))
             }
 
-            if (commitHashManifests.size() == imageManifests.size()) {
-                // all tags matching digest are commit hash tags
+            if (candidateManifests.size() == imageManifests.size()) {
+                // all tags matching digest are commit hash tags or branch tags no longer on remote
                 imageManifests.each { manifest ->
                     if (manifest.ageInDays(nowSec) > retentionDays) {
                         cleanableTagsList.add(manifest.tag)

--- a/src/com/boxboat/jenkins/library/git/GitRepo.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitRepo.groovy
@@ -10,6 +10,12 @@ class GitRepo implements Serializable {
 
     private shortHashLength = 12
 
+    static List<String> remoteBranches(String gitRemoteUrl) {
+        return Utils.resultOrTest(Config.pipeline.sh(returnStdout: true, script: """
+            git ls-remote --heads "${gitRemoteUrl}" | sed 's|.*refs/heads/\\(.*\\)|\\1|g'
+        """)?.trim()?.split('\n')?.findAll { it -> !it.isEmpty() }, ["master", "develop"])
+    }
+
     String getHash() {
         return Utils.resultOrTest(Config.pipeline.sh(returnStdout: true, script: """
             cd "${this.dir}"

--- a/src/com/boxboat/jenkins/pipeline/build/BoxBuild.groovy
+++ b/src/com/boxboat/jenkins/pipeline/build/BoxBuild.groovy
@@ -93,9 +93,11 @@ class BoxBuild extends BoxBase<BuildConfig> implements Serializable {
             if (isBranchTip) {
                 Config.pipeline.echo "isBranchTip: ${event}"
                 emitEvents.add(event)
-                def buildVersions = this.getBuildVersions()
+                def buildVersions = Config.getBuildVersions()
+                def repoPath = this.gitRepo.getRemotePath()
                 config.images.each { image ->
                     buildVersions.setEventImageVersion(event, image, buildTag)
+                    buildVersions.setImageRepoPath(image, repoPath)
                 }
                 buildVersions.save()
             }
@@ -103,7 +105,7 @@ class BoxBuild extends BoxBase<BuildConfig> implements Serializable {
 
     }
 
-    def summary(){
+    def summary() {
         String triggeredBuilds = ""
 
 

--- a/src/com/boxboat/jenkins/pipeline/deploy/BoxDeploy.groovy
+++ b/src/com/boxboat/jenkins/pipeline/deploy/BoxDeploy.groovy
@@ -184,7 +184,7 @@ class BoxDeploy extends BoxBase<DeployConfig> implements Serializable {
             Config.pipeline.error "'format' is required and must be 'yaml'or 'env'"
         }
 
-        def buildVersions = this.getBuildVersions()
+        def buildVersions = Config.getBuildVersions()
         Config.pipeline.sh """
             rm -f "${params.outFile}"
         """

--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -82,7 +82,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
     def promote() {
         def tagType = promotion.promoteToEvent.substring("tag/".length())
 
-        def buildVersions = this.getBuildVersions()
+        def buildVersions = Config.getBuildVersions()
 
         String gitCommitToTag
         String gitTagToTag
@@ -212,7 +212,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
             if (!config.gitTagDisable && (gitCommitToTag || gitTagToTag)) {
                 // resetting will remove build-versions
-                _buildVersions = null
+                Config.resetBuildVersions()
                 if (gitCommitToTag) {
                     gitRepo.fetchAndCheckoutCommit(gitCommitToTag)
                 } else if (gitTagToTag) {


### PR DESCRIPTION
- Fixes #31 
- Writes image repo path to a text file during build time at `build-versions/image-repos/<image-path>.txt`
- Image cleanup scripts look for a repo path corresponding to the image and if they find one, they call `git ls-remote --heads <remote>` on the repository to get branch listing
- If a branch no longer exists, the `commit-<branch>` tag is a candidate for cleanup if it's older than the retention period

As a side effect of accessing `getBuildVersions()` from `ImageManifests`, I moved it to a global in `Config.groovy` along with `GitAccount`.  This should be OK as `GitAccount` pulls all of it's configuration from `Config.global.git` and did not rely on any variables in `BoxBase`