### PR TITLE
Google Cloud: add GCloudRegistry and GCloudGKEDeployTarget

### DIFF
--- a/docs/config/global.md
+++ b/docs/config/global.md
@@ -7,6 +7,7 @@ All keys from the [Common Config](common.md) are valid in addition to the keys d
 Map of deployment targets.  Supported deployment target types are:
 
 - `com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget`
+- `com.boxboat.jenkins.library.gcloud.GCloudGKEDeployTarget`
 
 ```yaml
 deployTargetMap:
@@ -14,7 +15,18 @@ deployTargetMap:
     # kubernetes context to use
     contextName: boxboat
     # credential ID with kube config
-    credential: kubeconfig-dev 
+    credential: kubeconfig-dev
+  gke: !!com.boxboat.jenkins.library.gcloud.GCloudGKEDeployTarget
+    # gCloudAccountMap key to reference
+    gCloudAccountKey: default
+    # GKE cluster name
+    name: kube-cluster-name
+    # Google Cloud project name
+    project: gcloud-project
+    # specify either region or zone, not both; use region for regional clusters
+    region: us-central1
+    # specify either region or zone, not both; use zone for zonal clusters
+    zone: us-central1-a
 ```
 
 ## environmentMap
@@ -26,6 +38,19 @@ environmentMap:
   dev:
     # deployTargetMap key to reference
     deployTargetKey: dev01
+```
+
+## gCloudAccountMap
+
+Map of Google Cloud accounts for use with `GCloudGKEDeployTarget` and `GCloudRegistry`
+
+```yaml
+gCloudAccountMap:
+  default:
+    # name of the service account
+    account: service-account@gcloud-project.iam.gserviceaccount.com
+    # secret file credential with the service account JSON key
+    keyFileCredential: gcloud-key-file-credential
 ```
 
 ## git
@@ -78,7 +103,12 @@ notifyTargetMap:
 
 ## registryMap
 
-Map of Docker registries.
+Map of Docker registries.  Supported registry types are:
+
+Supported deployment target types are:
+
+- `com.boxboat.jenkins.library.docker.Registry` (the default)
+- `com.boxboat.jenkins.library.gcloud.GCloudRegistry`
 
 ```yaml
 registryMap:
@@ -90,6 +120,13 @@ registryMap:
     # {{ path }} is replaced with the image path
     # {{ tag }} is replaced with the image tag
     imageUrlReplace: https://dtr.boxboat.com/repositories/{{ path }}/{{ tag }}/linux/amd64/layers
+  gcr: !!com.boxboat.jenkins.library.gcloud.GCloudRegistry
+    scheme: https
+    host: gcr.io
+    # Google Cloud project
+    namespace: gcloud-project
+    # gCloudAccountMap key to reference
+    gCloudAccountKey: default
 ```
 
 ## vaultMap

--- a/resources/com/boxboat/jenkins/config.example.yaml
+++ b/resources/com/boxboat/jenkins/config.example.yaml
@@ -1,3 +1,8 @@
+awsProfileMap:
+  default:
+    region: us-east-1
+    accessKeyIdCredential: aws-access-key-id
+    secretAccessKeyCredential: aws-secret-access-key
 deployTargetMap:
   dev01: !!com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget
     contextName: boxboat
@@ -8,6 +13,11 @@ deployTargetMap:
   prod02: !!com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget
     contextName: boxboat
     credential: kubeconfig-prod-02
+  gke: !!com.boxboat.jenkins.library.gcloud.GCloudGKEDeployTarget
+    gCloudAccountKey: default
+    name: kube-cluster-name
+    project: gcloud-project
+    zone: us-central1-a
 environmentMap:
   dev:
     name: dev
@@ -18,6 +28,10 @@ environmentMap:
     replicaEnvironments:
       - name: prod-b
         deployTargetKey: prod02
+gCloudAccountMap:
+  default:
+    account: service-account@gcloud-project.iam.gserviceaccount.com
+    keyFileCredential: gcloud-key-file-credential
 git:
   buildVersionsUrl: git@github.com:boxboat/build-versions.git
   credential: git
@@ -35,6 +49,11 @@ registryMap:
     host: dtr.boxboat.com
     credential: registry
     imageUrlReplace: https://dtr.boxboat.com/repositories/{{ path }}/{{ tag }}/linux/amd64/layers
+  gcr: !!com.boxboat.jenkins.library.gcloud.GCloudRegistry
+    scheme: https
+    host: gcr.io
+    namespace: gcloud-project
+    gCloudAccountKey: default
 vaultMap:
   default:
     kvVersion: 1
@@ -42,12 +61,6 @@ vaultMap:
     secretIdCredential: vault-secret-id
     tokenCredential: vault-token
     url: http://localhost:8200
-awsProfileMap:
-  default:
-    region: us-east-1
-    accessKeyIdCredential: aws-access-key-id
-    secretAccessKeyCredential: aws-secret-access-key
-
 repo:
   common:
     defaultBranch: master

--- a/src/com/boxboat/jenkins/library/Utils.groovy
+++ b/src/com/boxboat/jenkins/library/Utils.groovy
@@ -27,6 +27,10 @@ class Utils implements Serializable {
         return value.replaceAll(/[^a-zA-Z0-9_]/, '_').toLowerCase()
     }
 
+    static String trimSlash(String value) {
+        return value.replaceAll(/(^\/+|\/+$)/, "")
+    }
+
     static String yamlPathScript(List<String> yamlPath, String fileName, String fileFormat) {
         if (!yamlPath) {
             return ""

--- a/src/com/boxboat/jenkins/library/config/GlobalConfig.groovy
+++ b/src/com/boxboat/jenkins/library/config/GlobalConfig.groovy
@@ -4,15 +4,20 @@ import com.boxboat.jenkins.library.aws.AwsProfile
 import com.boxboat.jenkins.library.deployTarget.IDeployTarget
 import com.boxboat.jenkins.library.docker.Registry
 import com.boxboat.jenkins.library.environment.Environment
+import com.boxboat.jenkins.library.gcloud.GCloudAccount
 import com.boxboat.jenkins.library.git.GitConfig
 import com.boxboat.jenkins.library.notify.INotifyTarget
 import com.boxboat.jenkins.library.vault.Vault
 
 class GlobalConfig extends BaseConfig<GlobalConfig> implements Serializable {
 
+    Map<String, AwsProfile> awsProfileMap
+
     Map<String, IDeployTarget> deployTargetMap
 
     Map<String, Environment> environmentMap
+
+    Map<String, GCloudAccount> gCloudAccountMap
 
     GitConfig git
 
@@ -24,7 +29,13 @@ class GlobalConfig extends BaseConfig<GlobalConfig> implements Serializable {
 
     Map<String, Vault> vaultMap
 
-    Map<String, AwsProfile> awsProfileMap
+    AwsProfile getAwsProfile(String key) {
+        def awsProfile = awsProfileMap.get(key)
+        if (!awsProfile) {
+            throw new Exception("awsProfileKey entry '${key}' does not exist in config file")
+        }
+        return awsProfile
+    }
 
     IDeployTarget getDeployTarget(String key) {
         def deployTarget = deployTargetMap.get(key)
@@ -42,6 +53,14 @@ class GlobalConfig extends BaseConfig<GlobalConfig> implements Serializable {
         return environment
     }
 
+    GCloudAccount getGCloudAccount(String key) {
+        def gCloudAccount = gCloudAccountMap.get(key)
+        if (!gCloudAccount) {
+            throw new Exception("gCloudAccount entry '${key}' does not exist in config file")
+        }
+        return gCloudAccount
+    }
+
     Registry getRegistry(String key) {
         def registry = registryMap.get(key)
         if (!registry) {
@@ -56,14 +75,6 @@ class GlobalConfig extends BaseConfig<GlobalConfig> implements Serializable {
             throw new Exception("vaultKey entry '${key}' does not exist in config file")
         }
         return vault
-    }
-
-    AwsProfile getAwsProfile(String key) {
-        def awsProfile = awsProfileMap.get(key)
-        if (!awsProfile) {
-            throw new Exception("awsProfileKey entry '${key}' does not exist in config file")
-        }
-        return awsProfile
     }
 
 }

--- a/src/com/boxboat/jenkins/library/docker/Image.groovy
+++ b/src/com/boxboat/jenkins/library/docker/Image.groovy
@@ -1,5 +1,6 @@
 package com.boxboat.jenkins.library.docker
 
+import com.boxboat.jenkins.library.Utils
 import com.boxboat.jenkins.library.config.BaseConfig
 import com.boxboat.jenkins.library.config.Config
 
@@ -13,12 +14,13 @@ class Image extends BaseConfig<Image> implements Serializable {
 
     String host
 
+    String namespace
+
     String path
 
     String tag
 
     Boolean trigger
-
 
     Image(Map<String, Object> config = [:]) {
         config.keySet().toList().each { k ->
@@ -48,11 +50,13 @@ class Image extends BaseConfig<Image> implements Serializable {
     }
 
     String getUrl() {
-        return (host ? "${host}/" : "") + "${path}:${tag ?: "latest"}"
+        return (host ? "${Utils.trimSlash(host)}/" : "") +
+                (namespace ? "${Utils.trimSlash(namespace)}/" : "") +
+                "${path}:${tag ?: "latest"}"
     }
 
     Image copy() {
-        return new Image(host: host, path: path, tag: tag)
+        return new Image(host: host, namespace: namespace, path: path, tag: tag)
     }
 
     Image reTag(Image newImage) {

--- a/src/com/boxboat/jenkins/library/docker/Registry.groovy
+++ b/src/com/boxboat/jenkins/library/docker/Registry.groovy
@@ -9,6 +9,8 @@ class Registry extends BaseConfig<Registry> implements Serializable {
 
     String host
 
+    String namespace
+
     String credential
 
     String imageUrlReplace

--- a/src/com/boxboat/jenkins/library/gcloud/GCloudAccount.groovy
+++ b/src/com/boxboat/jenkins/library/gcloud/GCloudAccount.groovy
@@ -1,0 +1,32 @@
+package com.boxboat.jenkins.library.gcloud
+
+import com.boxboat.jenkins.library.config.BaseConfig
+import com.boxboat.jenkins.library.config.Config
+
+class GCloudAccount extends BaseConfig<GCloudAccount> implements Serializable {
+
+    String account
+
+    String keyFileCredential
+
+    def withCredentials(Closure closure) {
+        def tempDir = Config.pipeline.sh(returnStdout: true, script: """
+            mktemp -d
+        """)?.trim()
+        try {
+            Config.pipeline.withEnv(["CLOUDSDK_CONFIG=${tempDir}"]) {
+                Config.pipeline.withCredentials([Config.pipeline.file(credentialsId: keyFileCredential, variable: 'GCLOUD_KEY_FILE')]) {
+                    Config.pipeline.sh """
+                        gcloud auth activate-service-account "${account}" --key-file="\$GCLOUD_KEY_FILE"
+                    """
+                }
+                closure()
+            }
+        } finally {
+            Config.pipeline.sh """
+                rm -rf "${tempDir}"
+            """
+        }
+    }
+
+}

--- a/src/com/boxboat/jenkins/library/gcloud/GCloudGKEDeployTarget.groovy
+++ b/src/com/boxboat/jenkins/library/gcloud/GCloudGKEDeployTarget.groovy
@@ -1,0 +1,49 @@
+package com.boxboat.jenkins.library.gcloud
+
+import com.boxboat.jenkins.library.config.BaseConfig
+import com.boxboat.jenkins.library.config.Config
+import com.boxboat.jenkins.library.deployTarget.IDeployTarget
+
+class GCloudGKEDeployTarget extends BaseConfig<GCloudGKEDeployTarget> implements IDeployTarget, Serializable {
+
+    String gCloudAccountKey
+
+    String name
+
+    String project
+
+    String region
+
+    String zone
+
+    @Override
+    void withCredentials(closure) {
+        Config.global.getGCloudAccount(gCloudAccountKey).withCredentials {
+            def tempDir = Config.pipeline.sh(returnStdout: true, script: """
+                mktemp -d
+            """)?.trim()
+            try {
+                def projectSwitch = project ? """
+                    --project="${project}"
+                """.trim() : ""
+                def regionSwitch = region ? """
+                    --region="${region}"
+                """.trim() : ""
+                def zoneSwitch = zone ? """
+                    --zone="${zone}"
+                """.trim() : ""
+                Config.pipeline.withEnv(["KUBECONFIG=${tempDir}/kube.config"]) {
+                    Config.pipeline.sh """
+                        gcloud container clusters get-credentials "${name}" ${projectSwitch} ${regionSwitch} ${zoneSwitch}
+                    """
+                    closure()
+                }
+            } finally {
+                Config.pipeline.sh """
+                    rm -rf "${tempDir}"
+                """
+            }
+        }
+    }
+
+}

--- a/src/com/boxboat/jenkins/library/gcloud/GCloudRegistry.groovy
+++ b/src/com/boxboat/jenkins/library/gcloud/GCloudRegistry.groovy
@@ -1,0 +1,31 @@
+package com.boxboat.jenkins.library.gcloud
+
+import com.boxboat.jenkins.library.config.Config
+import com.boxboat.jenkins.library.docker.Registry
+
+class GCloudRegistry extends Registry implements Serializable {
+
+    String gCloudAccountKey
+
+    @Override
+    def withCredentials(closure) {
+        Config.global.getGCloudAccount(gCloudAccountKey).withCredentials {
+            def tempDir = Config.pipeline.sh(returnStdout: true, script: """
+                mktemp -d
+            """)?.trim()
+            try {
+                Config.pipeline.withEnv(["DOCKER_CONFIG=${tempDir}"]) {
+                    Config.pipeline.sh """
+                        gcloud auth configure-docker --quiet
+                    """
+                    closure()
+                }
+            } finally {
+                Config.pipeline.sh """
+                    rm -rf "${tempDir}"
+                """
+            }
+        }
+    }
+
+}

--- a/src/com/boxboat/jenkins/pipeline/build/BoxBuild.groovy
+++ b/src/com/boxboat/jenkins/pipeline/build/BoxBuild.groovy
@@ -81,6 +81,7 @@ class BoxBuild extends BoxBase<BuildConfig> implements Serializable {
                         tags.each { String tag ->
                             def newImage = image.copy()
                             newImage.host = registry.host
+                            newImage.namespace = registry.namespace
                             newImage.tag = tag
                             image.reTag(newImage)
                             newImage.push()

--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -88,6 +88,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
         String gitTagToTag
         config.images.each { image ->
             image.host = promoteFromRegistry.host
+            image.namespace = promoteFromRegistry.namespace
             if (Utils.isImageTagEvent(promotion.event)) {
                 image.tag = Utils.imageTagFromEvent(promotion.event)
             } else {
@@ -175,6 +176,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
                     pushRegistries.each { pushRegistry ->
                         def newImageSemVer = image.copy()
                         newImageSemVer.host = pushRegistry.host
+                        newImageSemVer.namespace = pushRegistry.namespace
                         newImageSemVer.tag = nextSemVer.toString()
                         def newImageRef = image.copy()
                         newImageRef.tag = refTag

--- a/test-resources/com/boxboat/jenkins/test/library/config/globalConfig/test.yaml
+++ b/test-resources/com/boxboat/jenkins/test/library/config/globalConfig/test.yaml
@@ -1,3 +1,8 @@
+awsProfileMap:
+  default:
+    region: us-east-1
+    accessKeyIdCredential: aws-access-key-id
+    secretAccessKeyCredential: aws-secret-access-key
 deployTargetMap:
   dev01: !!com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget
     contextName: boxboat
@@ -8,6 +13,11 @@ deployTargetMap:
   prod02: !!com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget
     contextName: boxboat
     credential: kubeconfig-prod-02
+  gke: !!com.boxboat.jenkins.library.gcloud.GCloudGKEDeployTarget
+    gCloudAccountKey: default
+    name: kube-cluster-name
+    project: gcloud-project
+    zone: us-central1-a
 environmentMap:
   dev:
     name: dev
@@ -18,6 +28,10 @@ environmentMap:
     replicaEnvironments:
       - name: prod-b
         deployTargetKey: prod02
+gCloudAccountMap:
+  default:
+    account: service-account@gcloud-project.iam.gserviceaccount.com
+    keyFileCredential: gcloud-key-file-credential
 git:
   buildVersionsUrl: git@github.com:boxboat/build-versions.git
   credential: git
@@ -35,6 +49,11 @@ registryMap:
     host: dtr.boxboat.com
     credential: registry
     imageUrlReplace: https://dtr.boxboat.com/repositories/{{ path }}/{{ tag }}/linux/amd64/layers
+  gcr: !!com.boxboat.jenkins.library.gcloud.GCloudRegistry
+    scheme: https
+    host: gcr.io
+    namespace: gcloud-project
+    gCloudAccountKey: default
 vaultMap:
   default:
     kvVersion: 1
@@ -42,11 +61,6 @@ vaultMap:
     secretIdCredential: vault-secret-id
     tokenCredential: vault-token
     url: http://localhost:8200
-awsProfileMap:
-  default:
-    region: us-east-1
-    accessKeyIdCredential: aws-access-key-id
-    secretAccessKeyCredential: aws-secret-access-key
 repo:
   common:
     defaultBranch: master


### PR DESCRIPTION
Related: #33 

Adds `GCloudAccount` for logging in using service account key file stored as a Jenkins Secret File credential

Adds `GCloudRegistry` for Docker registry

Adds `GCloudGKEDeployTarget` for GKE Deployment

This will require the Google Cloud SDK to be installed on the agent