### PR TITLE
Update HelmDeploy with Helm 3 support

### DIFF
--- a/test/com/boxboat/jenkins/test/pipeline/deploy/kubernetes/HelmDeployTest.groovy
+++ b/test/com/boxboat/jenkins/test/pipeline/deploy/kubernetes/HelmDeployTest.groovy
@@ -13,29 +13,51 @@ class HelmDeployTest {
         def helmDeploy = new HelmDeploy(
                 directory: "./charts",
                 name: "test",
+                namespace: "ns1",
                 chart: ".",
                 options: [
                         "f": "values1.yaml"
                 ]
         )
+        helmDeploy.testMajorVersion(2)
         def installScript = helmDeploy.installScript(["f": "values2.yaml"])
-        assertEquals(installScript.trim(), """
+        assertEquals("""
             helm_current_dir=\$(pwd)
             cd "./charts"
-            helm install -f "values1.yaml" -f "values2.yaml" --name "test" "."
+            helm install -f "values1.yaml" -f "values2.yaml" --namespace "ns1" --name "test"  "."
             cd "\$helm_current_dir"
-        """.trim())
+        """.trim(), installScript.trim())
         def upgradeScript = helmDeploy.upgradeScript(["f": "values3.yaml", "install": true])
-        assertEquals(upgradeScript.trim(), """
+        assertEquals("""
             helm_current_dir=\$(pwd)
             cd "./charts"
-            helm upgrade -f "values1.yaml" -f "values3.yaml" --install "test" "."
+            helm upgrade -f "values1.yaml" -f "values3.yaml" --install --namespace "ns1" "test" "."
             cd "\$helm_current_dir"
-        """.trim())
+        """.trim(), upgradeScript.trim())
         def deleteScript = helmDeploy.deleteScript()
-        assertEquals(deleteScript.trim(),"""
-            helm delete "test" --purge
-        """.trim())
+        assertEquals("""
+            helm delete --purge "test"
+        """.trim(), deleteScript.trim())
+
+        helmDeploy.testMajorVersion(3)
+        installScript = helmDeploy.installScript(["f": "values2.yaml"])
+        assertEquals("""
+            helm_current_dir=\$(pwd)
+            cd "./charts"
+            helm install -f "values1.yaml" -f "values2.yaml" --namespace "ns1" "test" "."
+            cd "\$helm_current_dir"
+        """.trim(), installScript.trim())
+        upgradeScript = helmDeploy.upgradeScript(["f": "values3.yaml", "install": true])
+        assertEquals("""
+            helm_current_dir=\$(pwd)
+            cd "./charts"
+            helm upgrade -f "values1.yaml" -f "values3.yaml" --install --namespace "ns1" "test" "."
+            cd "\$helm_current_dir"
+        """.trim(), upgradeScript.trim())
+        deleteScript = helmDeploy.uninstallScript()
+        assertEquals("""
+            helm uninstall --namespace "ns1" "test"
+        """.trim(), deleteScript.trim())
     }
 
 }


### PR DESCRIPTION
Helm 3 has some subtle differences

```
// Install
2: helm install [CHART] [flags]
3: helm install [NAME] [CHART] [flags]

// Upgrade is the same
2: helm upgrade [RELEASE] [CHART] [flags]
3: helm upgrade [RELEASE] [CHART] [flags]

// Delete
2: helm delete [flags] RELEASE_NAME
3: helm uninstall RELEASE_NAME [...] [flags]
```

Namespace is also a global flag in Helm3, as Tiller is no longer around to track which release is installed in which namespace