### PR TITLE
Add image_info metadata to write version methods

### DIFF
--- a/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
+++ b/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
@@ -55,13 +55,13 @@ class GitBuildVersions implements Serializable {
         def dir = "${gitRepo.dir}/image-versions/${event}"
         def path = "${dir}/${Utils.alphaNumericDashLower(image.path)}.txt"
         def tag_key = "image_tag_${Utils.alphaNumericUnderscoreLower(image.path)}"
-        def info_key = "image_info_${Utils.alphaNumericUnderscoreLower(image.path)}"
+        def event_key = "image_event_${Utils.alphaNumericUnderscoreLower(image.path)}"
         def divider = format == "yaml" ? ": " : "="
         def rc = Config.pipeline.sh(returnStatus: true, script: """
             if [ -f "${path}" ]; then
                 version=\$(cat "$path")
                 echo "${tag_key}${divider}\\"\$version\\"" >> "$outFile"
-                echo "${info_key}${divider}\\"${event}\\"" >> "$outFile"
+                echo "${event_key}${divider}\\"${event}\\"" >> "$outFile"
                 exit 0
             fi
             exit 1
@@ -74,12 +74,12 @@ class GitBuildVersions implements Serializable {
             throw new Exception("invalid format: '${format}'")
         }
 
-        def key = "image_tag_${Utils.alphaNumericUnderscoreLower(image.path)}"
-        def info_key = "image_info_${Utils.alphaNumericUnderscoreLower(image.path)}"
+        def tag_key = "image_tag_${Utils.alphaNumericUnderscoreLower(image.path)}"
+        def event_key = "image_event_${Utils.alphaNumericUnderscoreLower(image.path)}"
         def divider = format == "yaml" ? ": " : "="
         Config.pipeline.sh """
-            echo "${key}${divider}\\"${version}\\"" >> "$outFile"
-            echo "${info_key}${divider}\\"${version}\\"" >> "$outFile"
+            echo "${tag_key}${divider}\\"${version}\\"" >> "$outFile"
+            echo "${event_key}${divider}\\"${version}\\"" >> "$outFile"
         """
     }
 

--- a/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
+++ b/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
@@ -54,12 +54,14 @@ class GitBuildVersions implements Serializable {
 
         def dir = "${gitRepo.dir}/image-versions/${event}"
         def path = "${dir}/${Utils.alphaNumericDashLower(image.path)}.txt"
-        def key = "image_tag_${Utils.alphaNumericUnderscoreLower(image.path)}"
+        def tag_key = "image_tag_${Utils.alphaNumericUnderscoreLower(image.path)}"
+        def info_key = "image_info_${Utils.alphaNumericUnderscoreLower(image.path)}"
         def divider = format == "yaml" ? ": " : "="
         def rc = Config.pipeline.sh(returnStatus: true, script: """
             if [ -f "${path}" ]; then
                 version=\$(cat "$path")
-                echo "${key}${divider}\\"\$version\\"" >> "$outFile"
+                echo "${tag_key}${divider}\\"\$version\\"" >> "$outFile"
+                echo "${info_key}${divider}\\"${event}\\"" >> "$outFile"
                 exit 0
             fi
             exit 1
@@ -73,9 +75,11 @@ class GitBuildVersions implements Serializable {
         }
 
         def key = "image_tag_${Utils.alphaNumericUnderscoreLower(image.path)}"
+        def info_key = "image_info_${Utils.alphaNumericUnderscoreLower(image.path)}"
         def divider = format == "yaml" ? ": " : "="
         Config.pipeline.sh """
             echo "${key}${divider}\\"${version}\\"" >> "$outFile"
+            echo "${info_key}${divider}\\"${version}\\"" >> "$outFile"
         """
     }
 


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

Exposes the metadata about the image tag i.e. what event or version - which could then be reference in a helm deployment