### PR TITLE
Add buildKit option

### DIFF
--- a/src/com/boxboat/jenkins/library/config/CommonConfigBase.groovy
+++ b/src/com/boxboat/jenkins/library/config/CommonConfigBase.groovy
@@ -7,6 +7,8 @@ import com.boxboat.jenkins.library.notify.NotifyConfig
 
 class CommonConfigBase<T> extends BaseConfig<T> {
 
+    Boolean buildKit = false
+
     String defaultBranch
 
     List<EventRegistryKey> eventRegistryKeys

--- a/src/com/boxboat/jenkins/library/docker/Compose.groovy
+++ b/src/com/boxboat/jenkins/library/docker/Compose.groovy
@@ -6,7 +6,10 @@ import com.boxboat.jenkins.library.config.Config
 class Compose implements Serializable {
 
     static String up(dir, profile) {
+
         Config.pipeline.sh """
+            export DOCKER_BUILDKIT=${Config.repo.buildKit ? 1 : 0}
+            export COMPOSE_DOCKER_CLI_BUILD=${Config.repo.buildKit ? 1 : 0}
             ${LibraryScript.run("compose-up.sh")} "$dir" "$profile"
         """
     }
@@ -19,6 +22,8 @@ class Compose implements Serializable {
 
     static String build(dir, profile) {
         Config.pipeline.sh """
+            export DOCKER_BUILDKIT=${Config.repo.buildKit ? 1 : 0}
+            export COMPOSE_DOCKER_CLI_BUILD=${Config.repo.buildKit ? 1 : 0}
             ${LibraryScript.run("compose-build.sh")} "$dir" "$profile"
         """
     }

--- a/test-resources/com/boxboat/jenkins/test/library/config/globalConfig/test.yaml
+++ b/test-resources/com/boxboat/jenkins/test/library/config/globalConfig/test.yaml
@@ -63,6 +63,7 @@ vaultMap:
     url: http://localhost:8200
 repo:
   common:
+    buildKit: true
     defaultBranch: master
     notify:
       targetMap:

--- a/test-resources/com/boxboat/jenkins/test/library/config/repoConfig/test.yaml
+++ b/test-resources/com/boxboat/jenkins/test/library/config/repoConfig/test.yaml
@@ -1,4 +1,5 @@
 common:
+  buildKit: true
   images:
   - apps/app-1
   - apps/app-2

--- a/test-resources/com/boxboat/jenkins/test/pipeline/build.jenkins
+++ b/test-resources/com/boxboat/jenkins/test/pipeline/build.jenkins
@@ -8,6 +8,7 @@ def execute() {
         dir: "./test",
         globalConfigPath: "com/boxboat/jenkins/config.example.yaml",
         config: [
+            buildKit: true,
             composeProfileMap: [
                 "dev" : "./build/docker/dev/",
                 "prod": "./build/docker/prod/",

--- a/test/com/boxboat/jenkins/test/library/config/GlobalConfigTest.groovy
+++ b/test/com/boxboat/jenkins/test/library/config/GlobalConfigTest.groovy
@@ -149,6 +149,7 @@ class GlobalConfigTest {
                                 ],
                                 repo: [
                                         common : new CommonConfig(
+                                                buildKit: true,
                                                 defaultBranch: "master",
                                                 notify: [
                                                         "targetMap"     : [

--- a/test/com/boxboat/jenkins/test/library/config/RepoConfigTest.groovy
+++ b/test/com/boxboat/jenkins/test/library/config/RepoConfigTest.groovy
@@ -47,6 +47,7 @@ class RepoConfigTest {
                         "test.yaml",
                         new RepoConfig(
                                 common: new CommonConfig(
+                                        buildKit: true,
                                         images: [
                                                 new Image("apps/app-1"),
                                                 new Image("apps/app-2"),


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

Add the ability to enable buildKit for `Compose`, which is part of docker-compose since [1.25.0](https://github.com/docker/compose/blob/master/CHANGELOG.md#1250-2019-11-18)
