### PR TITLE
Disable StrictHostKeyChecking when calling gitAccount.clone

### DIFF
--- a/src/com/boxboat/jenkins/library/git/GitAccount.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitAccount.groovy
@@ -58,6 +58,9 @@ class GitAccount implements Serializable {
             rm -rf "${targetDir}"
             mkdir -p "${targetDir}"
             cd "${targetDir}"
+            if [ -z "\$GIT_SSH_COMMAND" ]; then
+                export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+            fi
             git clone ${depthStr} "${remoteUrl}" .
         """
 


### PR DESCRIPTION
Adds a default environment variable if not already set when cloning in the method `gitAccount.clone` to disable StrictHostKeyChecking:

```
GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
```

Respects `GIT_SSH_COMMAND` if it is already set, as the user may desire some other behavior by default