### PR TITLE
Support Alternate Git Configurations

### DIFF
--- a/docs/config/common.md
+++ b/docs/config/common.md
@@ -22,6 +22,15 @@ common:
       registryKey: default
 ```
 
+## gitAlternateKey
+
+Alternate Git configuration to select from Global Config [git.gitAlternateMap](global.md#git)
+
+```yaml
+common:
+  gitAlternateKey: gitlab
+```
+
 ## images
 
 `images` are used in the following way:

--- a/docs/config/global.md
+++ b/docs/config/global.md
@@ -55,7 +55,7 @@ gCloudAccountMap:
 
 ## git
 
-Stores the git configuration.
+Stores the git configuration.  To select an alternate config, set a repo-specific [gitAlternateKey](common.md#gitAlternateKey)
 
 ```yaml
 git:
@@ -79,6 +79,15 @@ git:
   # {{ path }} is replaced with the git path
   # {{ hash }} is replaced with the git commit hash
   commitUrlReplace: https://github.com/boxboat/{{ path }}/commit/{{ hash }}
+  # alternate git configurations
+  # buildVersionsUrl, credential, and email are not allowed
+  # in alternate git configurations
+  gitAlternateMap:
+    gitlab:
+      remotePathRegex: gitlab\.com[:\/]boxboat\/(.*)\.git$
+      remoteUrlReplace: git@gitlab.com:boxboat/{{ path }}.git
+      branchUrlReplace: https://gitlab.com/boxboat/{{ path }}/tree/{{ branch }}
+      commitUrlReplace: https://gitlab.com/boxboat/{{ path }}/commit/{{ hash }}
 ```
 
 ## notifyTargetMap

--- a/resources/com/boxboat/jenkins/config.example.yaml
+++ b/resources/com/boxboat/jenkins/config.example.yaml
@@ -13,7 +13,7 @@ deployTargetMap:
   prod02: !!com.boxboat.jenkins.library.deployTarget.KubernetesDeployTarget
     contextName: boxboat
     credential: kubeconfig-prod-02
-  gke: !!com.boxboat.jenkins.library.gcloud.GCloudGKEDeployTarget
+  gke01: !!com.boxboat.jenkins.library.gcloud.GCloudGKEDeployTarget
     gCloudAccountKey: default
     name: kube-cluster-name
     project: gcloud-project
@@ -40,6 +40,12 @@ git:
   remoteUrlReplace: git@github.com:boxboat/{{ path }}.git
   branchUrlReplace: https://github.com/boxboat/{{ path }}/tree/{{ branch }}
   commitUrlReplace: https://github.com/boxboat/{{ path }}/commit/{{ hash }}
+  gitAlternateMap:
+    gitlab:
+      remotePathRegex: gitlab\.com[:\/]boxboat\/(.*)\.git$
+      remoteUrlReplace: git@gitlab.com:boxboat/{{ path }}.git
+      branchUrlReplace: https://gitlab.com/boxboat/{{ path }}/tree/{{ branch }}
+      commitUrlReplace: https://gitlab.com/boxboat/{{ path }}/commit/{{ hash }}
 notifyTargetMap:
   default: !!com.boxboat.jenkins.library.notify.SlackWebHookNotifyTarget
     credential: slack-webhook-url

--- a/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
+++ b/src/com/boxboat/jenkins/library/buildVersions/GitBuildVersions.groovy
@@ -183,7 +183,7 @@ class GitBuildVersions implements Serializable {
                 cat "${path}"
             fi
         """)?.trim()
-        return Utils.resultOrTest(result, Config.global.git.getRemotePath(Config.global.git.buildVersionsUrl)) ?: null
+        return Utils.resultOrTest(result, Config.getGitRemotePath(Config.global.git.buildVersionsUrl)) ?: null
     }
 
     def save() {
@@ -192,8 +192,8 @@ class GitBuildVersions implements Serializable {
                 gitRepo.pull()
                 gitRepo.commitAndPush("update build versions")
             }
-            if (Config.global.git.buildVersionsLockableResource) {
-                Config.pipeline.lock(Config.global.git.buildVersionsLockableResource, closure)
+            if (Config.getGitSelected().buildVersionsLockableResource) {
+                Config.pipeline.lock(Config.getGitSelected().buildVersionsLockableResource, closure)
             } else {
                 closure()
             }

--- a/src/com/boxboat/jenkins/library/config/CommonConfigBase.groovy
+++ b/src/com/boxboat/jenkins/library/config/CommonConfigBase.groovy
@@ -11,6 +11,8 @@ class CommonConfigBase<T> extends BaseConfig<T> {
 
     List<EventRegistryKey> eventRegistryKeys
 
+    String gitAlternateKey
+
     List<Image> images
 
     NotifyConfig notify

--- a/src/com/boxboat/jenkins/library/config/Config.groovy
+++ b/src/com/boxboat/jenkins/library/config/Config.groovy
@@ -2,6 +2,7 @@ package com.boxboat.jenkins.library.config
 
 import com.boxboat.jenkins.library.buildVersions.GitBuildVersions
 import com.boxboat.jenkins.library.git.GitAccount
+import com.boxboat.jenkins.library.git.GitConfig
 
 class Config implements Serializable {
 
@@ -29,6 +30,18 @@ class Config implements Serializable {
             _buildVersions.checkout()
         }
         return _buildVersions
+    }
+
+    static GitConfig getGitSelected() {
+        return global.git.getGitConfig(repo.gitAlternateKey)
+    }
+
+    static String getGitRemotePath(String url) {
+        return global.getGitRemotePath(repo.gitAlternateKey, url)
+    }
+
+    static String getGitRemoteUrl(String path) {
+        return global.getGitRemoteUrl(path)
     }
 
     static resetBuildVersions() {

--- a/src/com/boxboat/jenkins/library/config/GlobalConfig.groovy
+++ b/src/com/boxboat/jenkins/library/config/GlobalConfig.groovy
@@ -61,6 +61,29 @@ class GlobalConfig extends BaseConfig<GlobalConfig> implements Serializable {
         return gCloudAccount
     }
 
+    String getGitRemotePath(String key, String url) {
+        def gitConfig = git.getGitConfig(key)
+        if (!gitConfig.remotePathRegex) {
+            return ""
+        }
+        def prefix = key ? "${key}:" : ""
+        def matcher = url =~ gitConfig.remotePathRegex
+        return matcher.hasGroup() && matcher.size() > 0 ? "${prefix}${matcher[0][1]}" : null
+    }
+
+    String getGitRemoteUrl(String path) {
+        def matcher = path =~ /(.*):.*/
+        def key = matcher.hasGroup() && matcher.size() > 0 ? matcher[0][1] : null
+        def gitConfig = git.getGitConfig(key as String)
+        if (!gitConfig.remoteUrlReplace || !path) {
+            return ""
+        }
+        if (key) {
+            path = path.substring((key as String).length() + 1)
+        }
+        return GitConfig.replacePath(gitConfig.remoteUrlReplace, path)
+    }
+
     Registry getRegistry(String key) {
         def registry = registryMap.get(key)
         if (!registry) {

--- a/src/com/boxboat/jenkins/library/docker/ImageManifests.groovy
+++ b/src/com/boxboat/jenkins/library/docker/ImageManifests.groovy
@@ -50,7 +50,7 @@ class ImageManifests implements Serializable {
         def gitRepoPath = buildVersions.getImageRepoPath(image)
         if (gitRepoPath) {
             try {
-                branchMap = GitRepo.remoteBranches(Config.global.git.getRemoteUrl(gitRepoPath)).collectEntries { it ->
+                branchMap = GitRepo.remoteBranches(Config.getGitRemoteUrl(gitRepoPath)).collectEntries { it ->
                     [(Utils.cleanTag("commit/${it}")): it]
                 }
             } catch (Exception ignored) {

--- a/src/com/boxboat/jenkins/library/git/GitConfig.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitConfig.groovy
@@ -20,19 +20,17 @@ class GitConfig extends BaseConfig<GitConfig> implements Serializable {
 
     String commitUrlReplace
 
-    String getRemotePath(String url) {
-        if (!remotePathRegex) {
-            return ""
-        }
-        def matcher = url =~ remotePathRegex
-        return matcher.hasGroup() && matcher.size() > 0 ? matcher[0][1] : null
-    }
+    Map<String, GitConfig> gitAlternateMap
 
-    String getRemoteUrl(String path) {
-        if (!remoteUrlReplace || !path) {
-            return ""
+    GitConfig getGitConfig(String key) {
+        def gitConfig = this
+        if (key) {
+            gitConfig = gitAlternateMap.get(key)
         }
-        return replacePath(remoteUrlReplace, path)
+        if (!gitConfig) {
+            throw new Exception("git.gitAlternateMap entry '${key}' does not exist in config file")
+        }
+        return gitConfig
     }
 
     String getCommitUrl(String path, String hash) {
@@ -49,7 +47,7 @@ class GitConfig extends BaseConfig<GitConfig> implements Serializable {
         return replacePath(branchUrlReplace, path).replaceFirst(/(?i)\{\{\s+branch\s+\}\}/, branch)
     }
 
-    private String replacePath(String base, String path){
+    static String replacePath(String base, String path) {
         return base.replaceFirst(/(?i)\{\{\s+path\s+\}\}/, path)
     }
 }

--- a/src/com/boxboat/jenkins/library/git/GitRepo.groovy
+++ b/src/com/boxboat/jenkins/library/git/GitRepo.groovy
@@ -54,15 +54,15 @@ class GitRepo implements Serializable {
     }
 
     String getRemotePath() {
-        return Config.global.git.getRemotePath(getRemoteUrl())
+        return Config.getGitRemotePath(getRemoteUrl())
     }
 
     String getCommitUrl() {
-        return Config.global.git.getCommitUrl(getRemotePath(), getHash())
+        return Config.getGitSelected().getCommitUrl(getRemotePath(), getHash())
     }
 
     String getBranchUrl() {
-        return Config.global.git.getBranchUrl(getRemotePath(), getBranch())
+        return Config.getGitSelected().getBranchUrl(getRemotePath(), getBranch())
     }
 
     String getTagReferenceHash(String tag) {

--- a/src/com/boxboat/jenkins/pipeline/BoxBase.groovy
+++ b/src/com/boxboat/jenkins/pipeline/BoxBase.groovy
@@ -1,7 +1,6 @@
 package com.boxboat.jenkins.pipeline
 
 import com.boxboat.jenkins.library.Utils
-import com.boxboat.jenkins.library.buildVersions.GitBuildVersions
 import com.boxboat.jenkins.library.config.CommonConfigBase
 import com.boxboat.jenkins.library.config.Config
 import com.boxboat.jenkins.library.config.GlobalConfig
@@ -138,6 +137,7 @@ abstract class BoxBase<T extends CommonConfigBase> implements Serializable {
             config.merge(globalConfig.repo.common)
         }
         config.merge(globalConfig.repo."$configKey")
+        Config.repo = config
 
         // set null properties to non-null params
         Config.pipeline.params.keySet().toList().each { k ->
@@ -211,7 +211,6 @@ abstract class BoxBase<T extends CommonConfigBase> implements Serializable {
             def initialConfigObj = config.newFromObject(initialConfig)
             config.merge(initialConfigObj)
         }
-        Config.repo = config
 
         // set null top-level config properties to non-null params
         Config.pipeline.params.keySet().toList().each { k ->

--- a/test-resources/com/boxboat/jenkins/test/library/config/globalConfig/test.yaml
+++ b/test-resources/com/boxboat/jenkins/test/library/config/globalConfig/test.yaml
@@ -40,6 +40,12 @@ git:
   remoteUrlReplace: git@github.com:boxboat/{{ path }}.git
   branchUrlReplace: https://github.com/boxboat/{{ path }}/tree/{{ branch }}
   commitUrlReplace: https://github.com/boxboat/{{ path }}/commit/{{ hash }}
+  gitAlternateMap:
+    gitlab:
+      remotePathRegex: gitlab\.com[:\/]boxboat\/(.*)\.git$
+      remoteUrlReplace: git@gitlab.com:boxboat/{{ path }}.git
+      branchUrlReplace: https://gitlab.com/boxboat/{{ path }}/tree/{{ branch }}
+      commitUrlReplace: https://gitlab.com/boxboat/{{ path }}/commit/{{ hash }}
 notifyTargetMap:
   default: !!com.boxboat.jenkins.library.notify.SlackWebHookNotifyTarget
     credential: slack-webhook-url

--- a/test-resources/com/boxboat/jenkins/test/library/config/repoConfig/test.yaml
+++ b/test-resources/com/boxboat/jenkins/test/library/config/repoConfig/test.yaml
@@ -13,6 +13,7 @@ common:
     registryKey: default
   - event: tag/.*
     registryKey: default
+  gitAlternateKey: gitlab
 build:
   composeProfileMap:
     docker: ./build/docker

--- a/test/com/boxboat/jenkins/test/library/config/GitConfigTest.groovy
+++ b/test/com/boxboat/jenkins/test/library/config/GitConfigTest.groovy
@@ -1,0 +1,37 @@
+package com.boxboat.jenkins.test.library.config
+
+import com.boxboat.jenkins.library.config.GlobalConfig
+import com.boxboat.jenkins.library.git.GitConfig
+import org.junit.Test
+
+import static org.junit.Assert.assertEquals
+
+class GitConfigTest {
+
+    @Test
+    void gitConfigTest() throws Exception {
+        def global = new GlobalConfig().newFromYaml('''
+git:
+  buildVersionsUrl: git@github.com:boxboat/build-versions.git
+  credential: git
+  email: jenkins@boxboat.com
+  remotePathRegex: github\\.com[:\\/]boxboat\\/(.*)\\.git$
+  remoteUrlReplace: git@github.com:boxboat/{{ path }}.git
+  branchUrlReplace: https://github.com/boxboat/{{ path }}/tree/{{ branch }}
+  commitUrlReplace: https://github.com/boxboat/{{ path }}/commit/{{ hash }}
+  gitAlternateMap:
+    gitlab:
+      remotePathRegex: gitlab\\.com[:\\/]boxboat\\/(.*)\\.git$
+      remoteUrlReplace: git@gitlab.com:boxboat/{{ path }}.git
+      branchUrlReplace: https://gitlab.com/boxboat/{{ path }}/tree/{{ branch }}
+      commitUrlReplace: https://gitlab.com/boxboat/{{ path }}/commit/{{ hash }}
+''')
+        def rootPath = global.getGitRemotePath(null, "https://github.com/boxboat/path.git")
+        assertEquals("path", rootPath)
+        assertEquals("git@github.com:boxboat/path.git", global.getGitRemoteUrl(rootPath))
+        def selectedPath = global.getGitRemotePath("gitlab", "https://gitlab.com/boxboat/path.git")
+        assertEquals("gitlab:path", selectedPath)
+        assertEquals("git@gitlab.com:boxboat/path.git", global.getGitRemoteUrl(selectedPath))
+    }
+
+}

--- a/test/com/boxboat/jenkins/test/library/config/GlobalConfigTest.groovy
+++ b/test/com/boxboat/jenkins/test/library/config/GlobalConfigTest.groovy
@@ -52,7 +52,6 @@ class GlobalConfigTest {
 //        System.out.println("")
 //        System.out.println(yaml.dump(config))
         assertEquals(expectedConfig, config)
-        assertEquals(config.git.buildVersionsUrl, config.git.getRemoteUrl(config.git.getRemotePath(config.git.buildVersionsUrl)))
     }
 
     @Parameters(name = "{index}: {0}")
@@ -117,6 +116,14 @@ class GlobalConfigTest {
                                         remoteUrlReplace: 'git@github.com:boxboat/{{ path }}.git',
                                         branchUrlReplace: "https://github.com/boxboat/{{ path }}/tree/{{ branch }}",
                                         commitUrlReplace: "https://github.com/boxboat/{{ path }}/commit/{{ hash }}",
+                                        gitAlternateMap: [
+                                                "gitlab": new GitConfig(
+                                                        remotePathRegex: 'gitlab\\.com[:\\/]boxboat\\/(.*)\\.git$',
+                                                        remoteUrlReplace: 'git@gitlab.com:boxboat/{{ path }}.git',
+                                                        branchUrlReplace: "https://gitlab.com/boxboat/{{ path }}/tree/{{ branch }}",
+                                                        commitUrlReplace: "https://gitlab.com/boxboat/{{ path }}/commit/{{ hash }}",
+                                                ),
+                                        ],
                                 ),
                                 notifyTargetMap: [
                                         default: new SlackWebHookNotifyTarget(

--- a/test/com/boxboat/jenkins/test/library/config/RepoConfigTest.groovy
+++ b/test/com/boxboat/jenkins/test/library/config/RepoConfigTest.groovy
@@ -71,6 +71,7 @@ class RepoConfigTest {
                                                         registryKey: "default",
                                                 ),
                                         ],
+                                        "gitAlternateKey": "gitlab",
                                 ),
                                 build: new BuildConfig(
                                         composeProfileMap: [


### PR DESCRIPTION
Add `git.gitAlternateMap` to support alternate Git Configurations

This is useful if somebody has 2 Git services, such as GitHub and GitLab

The primary Git Configuration is always used for `buildVersionsUrl`, `credential`, and `email`

An alternate account can be selected on a per-repo basis by setting `gitAlternateKey`.  Default is just to use the primary

Git paths for alternate configurations will be prefixed with the key. i.e. an alternate `gitlab` with a repository `git@gitlab.com:boxboat/path.git` would be stored as `gitlab:path`

A precondition is to use the same Private Key to connect to both Git services, since a single key is written to `~/.ssh/id_rsa`