### PR TITLE
Add cleanBranch util for basic input sanitization

### DIFF
--- a/src/com/boxboat/jenkins/library/Utils.groovy
+++ b/src/com/boxboat/jenkins/library/Utils.groovy
@@ -10,7 +10,7 @@ class Utils implements Serializable {
         if (branch == null) {
             return null
         }
-        return branch.replaceAll(/[^a-zA-Z0-9\-.\/]/, ''])
+        return branch.replaceAll(/[^a-zA-Z0-9\-.\/]/, '')
     }
 
     static String cleanTag(String tag) {

--- a/src/com/boxboat/jenkins/library/Utils.groovy
+++ b/src/com/boxboat/jenkins/library/Utils.groovy
@@ -6,6 +6,13 @@ import java.nio.file.Paths
 
 class Utils implements Serializable {
 
+    static String cleanBranch(String branch) {
+        if (branch == null) {
+            return null
+        }
+        return branch.replaceAll(/[^a-zA-Z0-9\-.\/]/, ''])
+    }
+
     static String cleanTag(String tag) {
         if (tag == null) {
             return null

--- a/src/com/boxboat/jenkins/pipeline/BoxBase.groovy
+++ b/src/com/boxboat/jenkins/pipeline/BoxBase.groovy
@@ -157,6 +157,7 @@ abstract class BoxBase<T extends CommonConfigBase> implements Serializable {
         // update from Git
         gitRepo = Config.gitAccount.checkoutScm()
         if (overrideBranch) {
+            overrideBranch = Utils.cleanBranch(overrideBranch)
             Config.pipeline.echo "Changing Branch to '${overrideBranch}'"
             gitRepo.fetchAndCheckoutBranch(overrideBranch)
         }


### PR DESCRIPTION
Hi Folks!

This PR adds a basic input sanitization function for legal git branch characters, especially with the `overrideBranch` parameter field. 

This fixes an issue with copying and pasting text which can sometimes pick up non-printable characters, whitespace, etc, and fail in a confusing manner as a result.