### PR TITLE
Semver check take prereleases into account

### DIFF
--- a/src/com/boxboat/jenkins/library/SemVer.groovy
+++ b/src/com/boxboat/jenkins/library/SemVer.groovy
@@ -81,36 +81,11 @@ class SemVer implements Comparable<SemVer>, Serializable {
         return new SemVer(this.toString())
     }
 
-    /**
-     * Compare, ignoring pre-releases
-    **/
-    @NonCPS
-    int nonPreReleaseCompare(SemVer semver){
-        if (this.isValid && semver.isValid) {
-            if (this.major == semver.major && this.minor == semver.minor && this.patch == semver.patch) {
-                return 0
-            }
-            if (this.major > semver.major) {
-                return 1
-            } else if (this.major < semver.major) {
-                return -1
-            }
-            if (this.minor > semver.minor) {
-                return 1
-            } else if (this.minor < semver.minor) {
-                return -1
-            }
-            if (this.patch > semver.patch) {
-                return 1
-            } else if (this.patch < semver.patch) {
-                return -1
-            }
-        } else if (this.isValid) {
-            return 1
-        } else if (semver.isValid) {
-            return -1
-        }
-        return 0
+    SemVer copyNoPrerelease() {
+        def noPrerelease = copy()
+        noPrerelease.preRelease = null
+        noPrerelease.isPreRelease = false
+        return noPrerelease
     }
 
     @Override

--- a/src/com/boxboat/jenkins/library/SemVer.groovy
+++ b/src/com/boxboat/jenkins/library/SemVer.groovy
@@ -81,6 +81,38 @@ class SemVer implements Comparable<SemVer>, Serializable {
         return new SemVer(this.toString())
     }
 
+    /**
+     * Compare, ignoring pre-releases
+    **/
+    @NonCPS
+    int nonPreReleaseCompare(SemVer semver){
+        if (this.isValid && semver.isValid) {
+            if (this.major == semver.major && this.minor == semver.minor && this.patch == semver.patch) {
+                return 0
+            }
+            if (this.major > semver.major) {
+                return 1
+            } else if (this.major < semver.major) {
+                return -1
+            }
+            if (this.minor > semver.minor) {
+                return 1
+            } else if (this.minor < semver.minor) {
+                return -1
+            }
+            if (this.patch > semver.patch) {
+                return 1
+            } else if (this.patch < semver.patch) {
+                return -1
+            }
+        } else if (this.isValid) {
+            return 1
+        } else if (semver.isValid) {
+            return -1
+        }
+        return 0
+    }
+
     @Override
     @NonCPS
     int compareTo(SemVer semver) {

--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -111,8 +111,8 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
         def currSemVer = buildVersions.getRepoEventVersion(gitRepo.getRemotePath(), config.gitTagPrefix, promotion.promoteToEvent)
         def nextSemVer = currSemVer?.copy()
-        // If nextSemVer doesn't exist or is smaller than baseSemVer and is not a pre-release, use baseSemVer
-        if (nextSemVer == null || !nextSemVer.isValid || (baseSemVer.nonPreReleaseCompare(nextSemVer) > 0)) {
+        // If nextSemVer doesn't exist or its version without prerelease is smaller than baseSemVer, use baseSemVer
+        if (nextSemVer == null || !nextSemVer.isValid || (baseSemVer.compareTo(nextSemVer.copyNoPrerelease()) > 0)) {
             nextSemVer = baseSemVer.copy()
         } else if (tagType == "release") {
             nextSemVer.patch++

--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -111,8 +111,8 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
 
         def currSemVer = buildVersions.getRepoEventVersion(gitRepo.getRemotePath(), config.gitTagPrefix, promotion.promoteToEvent)
         def nextSemVer = currSemVer?.copy()
-        // If nextSemVer doesn't exist or is smaller than baseSemVer, use baseSemVer
-        if (nextSemVer == null || !nextSemVer.isValid || (baseSemVer.compareTo(nextSemVer) > 0)) {
+        // If nextSemVer doesn't exist or is smaller than baseSemVer and is not a pre-release, use baseSemVer
+        if (nextSemVer == null || !nextSemVer.isValid || (!nextSemVer.isPreRelease && baseSemVer.compareTo(nextSemVer) > 0)) {
             nextSemVer = baseSemVer.copy()
         } else if (tagType == "release") {
             nextSemVer.patch++

--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -112,7 +112,7 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
         def currSemVer = buildVersions.getRepoEventVersion(gitRepo.getRemotePath(), config.gitTagPrefix, promotion.promoteToEvent)
         def nextSemVer = currSemVer?.copy()
         // If nextSemVer doesn't exist or is smaller than baseSemVer and is not a pre-release, use baseSemVer
-        if (nextSemVer == null || !nextSemVer.isValid || (!nextSemVer.isPreRelease && baseSemVer.compareTo(nextSemVer) > 0)) {
+        if (nextSemVer == null || !nextSemVer.isValid || (baseSemVer.nonPreReleaseCompare(nextSemVer) > 0)) {
             nextSemVer = baseSemVer.copy()
         } else if (tagType == "release") {
             nextSemVer.patch++

--- a/test/com/boxboat/jenkins/test/library/SemVerTest.groovy
+++ b/test/com/boxboat/jenkins/test/library/SemVerTest.groovy
@@ -1,0 +1,65 @@
+package com.boxboat.jenkins.test.semver
+
+import com.boxboat.jenkins.library.SemVer
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameter
+import org.junit.runners.Parameterized.Parameters
+
+import static org.junit.Assert.assertEquals
+
+class SemVerTest {
+    static final int EQUAL = 0
+    static final int LESS_THAN = -1
+    static final int GREATER_THAN = 1
+
+    @Test
+    void testSemverNonPreReleaseCompareRCs() {
+        SemVer sv1
+        SemVer sv2
+        sv1 = new SemVer("0.1.0")
+        sv2 = new SemVer("0.1.0-rc1")
+        assertEquals(sv1.nonPreReleaseCompare(sv2), EQUAL)
+
+        sv1 = new SemVer("0.1.0-rc2")
+        sv2 = new SemVer("0.1.0-rc1")
+        assertEquals(sv1.nonPreReleaseCompare(sv2), EQUAL)
+
+        sv1 = new SemVer("0.2.0")
+        sv2 = new SemVer("0.1.0-rc1")
+        assertEquals(sv1.nonPreReleaseCompare(sv2), GREATER_THAN)
+        assertEquals(sv2.nonPreReleaseCompare(sv1), LESS_THAN)
+
+        sv1 = new SemVer("0.2.0-rc0")
+        sv2 = new SemVer("0.1.0-rc1")
+        assertEquals(sv1.nonPreReleaseCompare(sv2), GREATER_THAN)
+        assertEquals(sv2.nonPreReleaseCompare(sv1), LESS_THAN)
+    }
+
+    @Test
+    void testSemverCompareRC() {
+        SemVer sv1
+        SemVer sv2
+
+        sv1 = new SemVer("0.1.0")
+        sv2 = new SemVer("0.1.0-rc1")
+        assertEquals(sv1.compareTo(sv2), GREATER_THAN)
+        assertEquals(sv2.compareTo(sv1), LESS_THAN)
+
+        sv1 = new SemVer("0.1.0-rc2")
+        sv2 = new SemVer("0.1.0-rc1")
+        assertEquals(sv1.compareTo(sv2), EQUAL)
+
+        sv1 = new SemVer("0.2.0")
+        sv2 = new SemVer("0.1.0-rc1")
+        assertEquals(sv1.nonPreReleaseCompare(sv2), GREATER_THAN)
+        assertEquals(sv2.nonPreReleaseCompare(sv1), LESS_THAN)
+
+        sv1 = new SemVer("0.2.0-rc0")
+        sv2 = new SemVer("0.1.0-rc1")
+        assertEquals(sv1.nonPreReleaseCompare(sv2), GREATER_THAN)
+        assertEquals(sv2.nonPreReleaseCompare(sv1), LESS_THAN)
+    }
+
+}

--- a/test/com/boxboat/jenkins/test/library/SemVerTest.groovy
+++ b/test/com/boxboat/jenkins/test/library/SemVerTest.groovy
@@ -1,4 +1,4 @@
-package com.boxboat.jenkins.test.semver
+package com.boxboat.jenkins.test.library
 
 import com.boxboat.jenkins.library.SemVer
 import org.junit.Test
@@ -15,26 +15,26 @@ class SemVerTest {
     static final int GREATER_THAN = 1
 
     @Test
-    void testSemverNonPreReleaseCompareRCs() {
+    void testSemverNoPrerelease() {
         SemVer sv1
         SemVer sv2
         sv1 = new SemVer("0.1.0")
         sv2 = new SemVer("0.1.0-rc1")
-        assertEquals(sv1.nonPreReleaseCompare(sv2), EQUAL)
+        assertEquals(sv1.copyNoPrerelease().compareTo(sv2.copyNoPrerelease()), EQUAL)
 
         sv1 = new SemVer("0.1.0-rc2")
         sv2 = new SemVer("0.1.0-rc1")
-        assertEquals(sv1.nonPreReleaseCompare(sv2), EQUAL)
+        assertEquals(sv1.copyNoPrerelease().compareTo(sv2.copyNoPrerelease()), EQUAL)
 
         sv1 = new SemVer("0.2.0")
         sv2 = new SemVer("0.1.0-rc1")
-        assertEquals(sv1.nonPreReleaseCompare(sv2), GREATER_THAN)
-        assertEquals(sv2.nonPreReleaseCompare(sv1), LESS_THAN)
+        assertEquals(sv1.copyNoPrerelease().compareTo(sv2.copyNoPrerelease()), GREATER_THAN)
+        assertEquals(sv2.copyNoPrerelease().compareTo(sv1.copyNoPrerelease()), LESS_THAN)
 
         sv1 = new SemVer("0.2.0-rc0")
         sv2 = new SemVer("0.1.0-rc1")
-        assertEquals(sv1.nonPreReleaseCompare(sv2), GREATER_THAN)
-        assertEquals(sv2.nonPreReleaseCompare(sv1), LESS_THAN)
+        assertEquals(sv1.copyNoPrerelease().compareTo(sv2.copyNoPrerelease()), GREATER_THAN)
+        assertEquals(sv2.copyNoPrerelease().compareTo(sv1.copyNoPrerelease()), LESS_THAN)
     }
 
     @Test
@@ -53,13 +53,13 @@ class SemVerTest {
 
         sv1 = new SemVer("0.2.0")
         sv2 = new SemVer("0.1.0-rc1")
-        assertEquals(sv1.nonPreReleaseCompare(sv2), GREATER_THAN)
-        assertEquals(sv2.nonPreReleaseCompare(sv1), LESS_THAN)
+        assertEquals(sv1.compareTo(sv2), GREATER_THAN)
+        assertEquals(sv2.compareTo(sv1), LESS_THAN)
 
         sv1 = new SemVer("0.2.0-rc0")
         sv2 = new SemVer("0.1.0-rc1")
-        assertEquals(sv1.nonPreReleaseCompare(sv2), GREATER_THAN)
-        assertEquals(sv2.nonPreReleaseCompare(sv1), LESS_THAN)
+        assertEquals(sv1.compareTo(sv2), GREATER_THAN)
+        assertEquals(sv2.compareTo(sv1), LESS_THAN)
     }
 
 }


### PR DESCRIPTION
Fixes regression caused by [#67](https://github.com/boxboat/dockhand/pull/67). Originally we were not respecting the base semver in the jenkins.yaml if it was greater than the current semver. The fix did not take pre-release semvers into account and this caused RCs off of the `baseSemVer` to always restart their incrementing from the `baseSemVer`. 
If we just don't use `baseSemVer` when the previousSemVer was an RC this will cause an issue if we move to a new base without promoting the last RC