### PR TITLE
add checkSuperseded to BoxDeploy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.4.12'
     implementation group: 'com.cloudbees', name: 'groovy-cps', version: '1.32'
     implementation group: 'org.jenkins-ci.main', name: 'jenkins-core', version: '2.277'
+    compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
 
     // @grab dependencies
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'


### PR DESCRIPTION
Add method to check whether build has been superseded.  Useful to prevent deployment storms when many builds trigger the same deployment