### PR TITLE
Fix first promote when using gitTagPrefix

### DIFF
--- a/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
+++ b/src/com/boxboat/jenkins/pipeline/promote/BoxPromote.groovy
@@ -395,17 +395,20 @@ class BoxPromote extends BoxBase<PromoteConfig> implements Serializable {
         promoteVersionString = nextSemVer.toString()
         setVersionChange(gitCommitToTag, gitTagToTag)
 
+        String previousVersion = nextSemVer.getPreviousVersion()
+        if (!previousVersion) {
+            previousVersion = gitRepo.firstCommit()
+        } else if (config.gitTagPrefix) {
+            previousVersion = "${config.gitTagPrefix}${nextSemVer.getPreviousVersion()}"
+        }
+
         if (gitCommitToTag) {
-            if (config.gitTagPrefix) {
-                commits = gitRepo.getCommitsBetween("${config.gitTagPrefix}${nextSemVer.getPreviousVersion()}", gitCommitToTag)
-            } else {
-                commits = gitRepo.getCommitsBetween(nextSemVer.getPreviousVersion(), gitCommitToTag)
-            }
+            commits = gitRepo.getCommitsBetween(previousVersion, gitCommitToTag)
         } else if (gitTagToTag) {
             if (config.gitTagPrefix) {
-                commits = gitRepo.getCommitsBetween("${config.gitTagPrefix}${nextSemVer.getPreviousVersion()}", "${config.gitTagPrefix}${gitTagToTag}")
+                commits = gitRepo.getCommitsBetween(previousVersion, "${config.gitTagPrefix}${gitTagToTag}")
             } else {
-                commits = gitRepo.getCommitsBetween(nextSemVer.getPreviousVersion(), gitTagToTag)
+                commits = gitRepo.getCommitsBetween(previousVersion, gitTagToTag)
             }
         }
     }


### PR DESCRIPTION
When doing the first promotion of a repo using the `gitTagPrefix` configuration option, it fails because it tries to show the commit history compared to a previous version that doesn't exist, like:

```
git log --pretty=format:{"author":"%ce","hash":"%H","date":"%ct"}, my-custom-git-tag-prefix/...611a9f8dddc0
```

There's some special handling inside `gitRepo.getCommitsBetween` that will fall back to the first commit in the repo if the first commit is empty, but there's no handling for that case if the `gitTagPrefix` is set.

This PR moves up the logic for handling the empty case a little earlier, so that it can handle the `gitTagPrefix` case as well.